### PR TITLE
:bug: Fix financial doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Mindee python SDK
 
+## v1.1.2 (2020-02-19)
+
+### Fix
+
+* :bug: Fixed FinancialDoc invoice version and reconstruction
+
 ## v1.1.1 (2020-01-31)
 
 ### Chg

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mindee API helper library for python
+# Receipt, passport and invoice OCR python helper for Mindee API
 
 The full documentation is available [here](https://mindee.com/documentation/get-started/setup-your-account)
 

--- a/mindee/documents/financial_document.py
+++ b/mindee/documents/financial_document.py
@@ -192,7 +192,7 @@ class FinancialDocument(Document):
         :param invoice_token: Invoices API token
         """
         if "pdf" in input_file.file_extension:
-            url = os.path.join(base_url, "invoices", "v1", "predict")
+            url = os.path.join(base_url, "invoices", "v2", "predict")
             return request(url, input_file, invoice_token, include_words)
         else:
             url = os.path.join(base_url, "expense_receipts", "v3", "predict")
@@ -218,8 +218,9 @@ class FinancialDocument(Document):
         total_vat = 0
         reconstructed_total = 0
         for tax in self.taxes:
-            total_vat += tax.value
-            reconstructed_total += tax.value + 100 * tax.value / tax.rate
+            if tax.rate is not None and tax.rate != 0:
+                total_vat += tax.value
+                reconstructed_total += tax.value + 100 * tax.value / tax.rate
 
         # Sanity check
         if total_vat <= 0:

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -6,3 +6,4 @@ setuptools~=49.2.0
 matplotlib~=3.1.2
 numpy~=1.18.5
 PyMuPDF~=1.18.1
+pytest-cov~=2.11.1

--- a/tests/documents/test_financial_doc.py
+++ b/tests/documents/test_financial_doc.py
@@ -236,6 +236,14 @@ def test__invoice_taxes_match_total_incl_3(invoice_pred):
     assert financial_doc.checklist["taxes_match_total_incl"] is False
 
 
+def test__shouldnt_raise_when_tax_rate_none(invoice_pred):
+    # sanity check with null tax
+    invoice_pred["total_incl"] = {"value": 507.25, "probability": 0.6}
+    invoice_pred["taxes"] = [{"rate": "N/A", "value": 0., "probability": 0.5}]
+    financial_doc = FinancialDocument(invoice_pred)
+    assert financial_doc.checklist["taxes_match_total_incl"] is False
+
+
 def test_compare_1(financial_doc_from_invoice_object):
     # Compare same object must return all True
     benchmark = FinancialDocument.compare(financial_doc_from_invoice_object, financial_doc_from_invoice_object)

--- a/tests/documents/test_invoice.py
+++ b/tests/documents/test_invoice.py
@@ -252,6 +252,15 @@ def test__taxes_plus_total_excl_match_total_incl_3(invoice_pred):
     assert invoice.checklist["taxes_match_total_incl"] is False
 
 
+def test__shouldnt_raise_when_tax_rate_none(invoice_pred):
+    # sanity check with null tax
+    invoice_pred["total_excl"] = {"value": 456.15, "probability": 0.6}
+    invoice_pred["total_incl"] = {"value": 507.25, "probability": 0.6}
+    invoice_pred["taxes"] = [{"rate": "N/A", "value": 0., "probability": 0.5}]
+    invoice = Invoice(invoice_pred)
+    assert invoice.checklist["taxes_match_total_incl"] is False
+
+
 def test_compare_1(invoice_object):
     # Compare same object must return all True
     benchmark = Invoice.compare(invoice_object, invoice_object)


### PR DESCRIPTION
# PR Details

Fix for FinancialDocument API

## Description

The Invoice version used for FinanicialDocument was "v1" and it led to errors.
The tax rate can now be None with the V2, fixed this error.

## How Has This Been Tested

Fully tested

## Types of changes

- [ x] Docs change / refactoring / dependency upgrade
- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [ x] My code follows the code style of this project.
- [ x] I have added tests to cover my changes.
- [x ] All new and existing tests passed.