### PR TITLE
Fix broken inputs test

### DIFF
--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -5,7 +5,7 @@ import fitz
 
 def test_mpdf_reconstruct():
     with pytest.raises(Exception):
-        Inputs('./tests/data/invoices/invoice_6p.pdf', cut_pdf=True, n_pdf_pages=4)
+        Inputs("./tests/data/invoices/invoice_6p.pdf", cut_pdf=True, n_pdf_pages=4)
 
 
 def test_mpdf_reconstruct_check_n_pages():
@@ -13,25 +13,26 @@ def test_mpdf_reconstruct_check_n_pages():
     input_obj_2 = Inputs('./tests/data/invoices/invoice_6p.pdf', cut_pdf=True, n_pdf_pages=2)
     input_obj_1 = Inputs('./tests/data/invoices/invoice_6p.pdf', cut_pdf=True, n_pdf_pages=1)
 
+    # re-initialize file pointer
     input_obj_3.file_object.seek(0)
     input_obj_2.file_object.seek(0)
     input_obj_1.file_object.seek(0)
 
     src_3 = fitz.open(
-                stream=input_obj_3.file_object.read(),
-                filetype="application/pdf",
-                filename="test.pdf"
-            )
+        stream=input_obj_3.file_object.read(),
+        filetype="application/pdf",
+        filename="test.pdf",
+    )
     src_2 = fitz.open(
-                stream=input_obj_2.file_object.read(),
-                filetype="application/pdf",
-                filename="test.pdf"
-            )
+        stream=input_obj_2.file_object.read(),
+        filetype="application/pdf",
+        filename="test.pdf",
+    )
     src_1 = fitz.open(
-                stream=input_obj_1.file_object.read(),
-                filetype="application/pdf",
-                filename="test.pdf"
-            )
+        stream=input_obj_1.file_object.read(),
+        filetype="application/pdf",
+        filename="test.pdf",
+    )
     assert len(src_3) == 3
     assert len(src_2) == 2
     assert len(src_1) == 1

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -12,6 +12,11 @@ def test_mpdf_reconstruct_check_n_pages():
     input_obj_3 = Inputs('./tests/data/invoices/invoice_6p.pdf', cut_pdf=True, n_pdf_pages=3)
     input_obj_2 = Inputs('./tests/data/invoices/invoice_6p.pdf', cut_pdf=True, n_pdf_pages=2)
     input_obj_1 = Inputs('./tests/data/invoices/invoice_6p.pdf', cut_pdf=True, n_pdf_pages=1)
+
+    input_obj_3.file_object.seek(0)
+    input_obj_2.file_object.seek(0)
+    input_obj_1.file_object.seek(0)
+
     src_3 = fitz.open(
                 stream=input_obj_3.file_object.read(),
                 filetype="application/pdf",


### PR DESCRIPTION
# PR Details

Fix a bug in inputs test. 

## Description

The file cursor was not re-initialized causing the .read() method to return b""

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

