### PR TITLE
Fix blank pdf - use pages.get_cdrawings()

### DIFF
--- a/mindee/inputs.py
+++ b/mindee/inputs.py
@@ -62,7 +62,7 @@ class Inputs(object):
                 if count_pages > 3:
                     self.merge_pdf_pages([0, count_pages - 2, count_pages - 1][:n_pdf_pages])
 
-            self.check_if_document_is_empty(count_pages)
+            self.check_if_document_is_empty()
 
 
     @staticmethod
@@ -126,9 +126,8 @@ class Inputs(object):
         self.file_object = io.BytesIO(doc.write())
 
 
-    def check_if_document_is_empty(self, pages_number):
+    def check_if_document_is_empty(self):
         """
-        :param pages_number: List of pages number to use for merging in the original pdf
         :return: (void) Check if the document contain only empty pages
         """
 
@@ -139,6 +138,10 @@ class Inputs(object):
         )
         fitz.open()
         for page in src:
-            if len(page.getImageList()) > 0 or page.getText():
+            if (
+                len(page.get_images()) > 0
+                or len(page.get_cdrawings()) > 0
+                or len(page.get_text()) > 0
+            ):
                 return
         raise Exception("PDF pages are empty")

--- a/mindee/inputs.py
+++ b/mindee/inputs.py
@@ -140,7 +140,7 @@ class Inputs(object):
         for page in src:
             if (
                 len(page.get_images()) > 0
-                or len(page.get_cdrawings()) > 0
+                or len(page.get_cdrawings()) > 1
                 or len(page.get_text()) > 0
             ):
                 return

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ requests~=2.23.0
 pytz~=2021.1
 setuptools~=49.2.0
 matplotlib~=3.1.2
-PyMuPDF~=1.18.6
+PyMuPDF~=1.18.17


### PR DESCRIPTION
# PR Details

- use `page.get_cdrawings()` to check if PDF page has any "path" within in addition to image or text to check if page is blank or not.
- upgrade pymupdf to 1.18.17 (to access the newest and fasted method `page.get_cdrawings()`
- remove unused parameter in `check_if_document_is_empty` function.

## Related Issue
Some PDF files are recognized as blank (zero page) #25

## Types of changes
- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)