### PR TITLE
chg: :art: :bug: better url management + Windows URL fix

### DIFF
--- a/mindee/__init__.py
+++ b/mindee/__init__.py
@@ -9,14 +9,6 @@ from mindee.documents.financial_document import FinancialDocument
 from mindee.documents.invoice import Invoice
 from mindee.documents.passport import Passport
 
-DOCUMENT_CLASSES = {
-    "receipt": Receipt,
-    "invoice": Invoice,
-    "financial_document": FinancialDocument,
-    "passport": Passport,
-    "license_plate": CarPlate,
-}
-
 
 class Client(object):
     def __init__(
@@ -36,20 +28,13 @@ class Client(object):
         """
         assert type(raise_on_error) == bool
         self.raise_on_error = raise_on_error
-        self.base_url = "https://api.mindee.net/v1/products/mindee/"
         self.expense_receipt_token = expense_receipt_token
         self.invoice_token = invoice_token
         self.passport_token = passport_token
         self.license_plate_token = license_plate_token
 
     def parse_receipt(
-        self,
-        file,
-        input_type="path",
-        version="3",
-        cut_pdf=True,
-        include_words=False,
-        cut_pdf_mode=3,
+        self, file, input_type="path", cut_pdf=True, include_words=False, cut_pdf_mode=3
     ):
         """
         :param cut_pdf_mode: Number (between 1 and 3 incl.) of pages to reconstruct a pdf with.
@@ -60,7 +45,6 @@ class Client(object):
         :param cut_pdf: Automatically reconstruct pdf with more than 4 pages
         :param input_type: String in {'path', 'stream', 'base64'}
         :param file: Receipt filepath (allowed jpg, png, tiff, pdf)
-        :param version: expense_receipt api version
         :return: Wrapped response with Receipts objects parsed
         """
         if not self.expense_receipt_token:
@@ -71,14 +55,106 @@ class Client(object):
         input_file = Inputs(file, input_type, cut_pdf=cut_pdf, n_pdf_pages=cut_pdf_mode)
 
         response = Receipt.request(
-            input_file,
-            self.base_url,
-            self.expense_receipt_token,
-            version,
-            include_words,
+            input_file, self.expense_receipt_token, include_words,
         )
 
         return self._wrap_response(input_file, response, "receipt")
+
+    def parse_passport(self, file, input_type="path", cut_pdf=True, cut_pdf_mode=3):
+        """
+        :param cut_pdf_mode: Number (between 1 and 3 incl.) of pages to reconstruct a pdf with.
+                        if 1: pages [0]
+                        if 2: pages [0, n-2]
+                        if 3: pages [0, n-2, n-1]
+        :param cut_pdf: Automatically reconstruct pdf with more than 4 pages
+        :param input_type: String in {'path', 'stream', 'base64'}
+        :param file: Passport filepath (allowed jpg, png, pdf)
+        :return: Wrapped response with passports objects parsed
+        """
+        if not self.passport_token:
+            raise Exception(
+                "Missing 'passport_token' arg in parse_passport() function."
+            )
+
+        input_file = Inputs(file, input_type, cut_pdf=cut_pdf, n_pdf_pages=cut_pdf_mode)
+
+        response = Passport.request(input_file, self.passport_token)
+
+        return self._wrap_response(input_file, response, "passport")
+
+    def parse_license_plate(
+        self, file, input_type="path", cut_pdf=True, cut_pdf_mode=3
+    ):
+        """
+        :param cut_pdf_mode: Number (between 1 and 3 incl.) of pages to reconstruct a pdf with.
+                        if 1: pages [0]
+                        if 2: pages [0, n-2]
+                        if 3: pages [0, n-2, n-1]
+        :param cut_pdf: Automatically reconstruct pdf with more than 4 pages
+        :param input_type: String in {'path', 'stream', 'base64'}
+        :param file: CarPlate filepath (allowed jpg, png, pdf)
+        :return: Wrapped response with CarPlates objects parsed
+        """
+        if not self.license_plate_token:
+            raise Exception(
+                "Missing 'license_plate_token' arg in license_plate_token() function."
+            )
+
+        input_file = Inputs(file, input_type, cut_pdf=cut_pdf, n_pdf_pages=cut_pdf_mode)
+
+        response = CarPlate.request(input_file, self.license_plate_token)
+
+        return self._wrap_response(input_file, response, "license_plate")
+
+    def parse_invoice(
+        self, file, input_type="path", cut_pdf=True, include_words=False, cut_pdf_mode=3
+    ):
+        """
+        :param cut_pdf_mode: Number (between 1 and 3 incl.) of pages to reconstruct a pdf with.
+                        if 1: pages [0]
+                        if 2: pages [0, n-2]
+                        if 3: pages [0, n-2, n-1]
+        :param include_words: Bool, extract all words into http_response
+        :param cut_pdf: Automatically reconstruct pdf with more than 4 pages
+        :param input_type: String in {'path', 'stream', 'base64'}
+        :param file: Invoice filepath (allowed jpg, png, pdf)
+        :return: Wrapped response with Invoices objects parsed
+        """
+        if not self.invoice_token:
+            raise Exception("Missing 'invoice_token' arg in parse_invoice() function.")
+
+        input_file = Inputs(file, input_type, cut_pdf=cut_pdf, n_pdf_pages=cut_pdf_mode)
+
+        response = Invoice.request(input_file, self.invoice_token, include_words)
+
+        return self._wrap_response(input_file, response, "invoice")
+
+    def parse_financial_document(
+        self, file, input_type="path", cut_pdf=True, include_words=False, cut_pdf_mode=3
+    ):
+        """
+        :param cut_pdf_mode: Number (between 1 and 3 incl.) of pages to reconstruct a pdf with.
+                        if 1: pages [0]
+                        if 2: pages [0, n-2]
+                        if 3: pages [0, n-2, n-1]
+        :param include_words: Bool, extract all words into http_response
+        :param cut_pdf: Automatically reconstruct pdf with more than 4 pages
+        :param input_type: String in {'path', 'stream', 'base64'}
+        :param file: Invoice or Receipt filepath (allowed jpg, png, pdf)
+        :return: Wrapped response with FinancialDocument objects parsed
+        """
+        if not self.invoice_token or not self.expense_receipt_token:
+            raise Exception(
+                "parse_invoice() function must include 'invoice_token' and 'expense_receipt_token' args."
+            )
+
+        input_file = Inputs(file, input_type, cut_pdf=cut_pdf, n_pdf_pages=cut_pdf_mode)
+
+        response = FinancialDocument.request(
+            input_file, self.expense_receipt_token, self.invoice_token, include_words,
+        )
+
+        return self._wrap_response(input_file, response, "financial_document")
 
     def _wrap_response(self, input_file, response, document_type):
         """
@@ -104,137 +180,14 @@ class Client(object):
 
         return Response.format_response(dict_response, document_type, input_file)
 
-    def parse_passport(
-        self,
-        file,
-        input_type="path",
-        version="1",
-        cut_pdf=True,
-        cut_pdf_mode=3,
-    ):
-        """
-        :param cut_pdf_mode: Number (between 1 and 3 incl.) of pages to reconstruct a pdf with.
-                        if 1: pages [0]
-                        if 2: pages [0, n-2]
-                        if 3: pages [0, n-2, n-1]
-        :param cut_pdf: Automatically reconstruct pdf with more than 4 pages
-        :param input_type: String in {'path', 'stream', 'base64'}
-        :param file: Passport filepath (allowed jpg, png, pdf)
-        :param version: passport api version
-        :return: Wrapped response with passports objects parsed
-        """
-        if not self.passport_token:
-            raise Exception(
-                "Missing 'passport_token' arg in parse_passport() function."
-            )
 
-        input_file = Inputs(file, input_type, cut_pdf=cut_pdf, n_pdf_pages=cut_pdf_mode)
-
-        response = Passport.request(
-            input_file, self.base_url, self.passport_token, version
-        )
-
-        return self._wrap_response(input_file, response, "passport")
-
-    def parse_license_plate(
-        self,
-        file,
-        input_type="path",
-        version="1",
-        cut_pdf=True,
-        cut_pdf_mode=3,
-    ):
-        """
-        :param cut_pdf_mode: Number (between 1 and 3 incl.) of pages to reconstruct a pdf with.
-                        if 1: pages [0]
-                        if 2: pages [0, n-2]
-                        if 3: pages [0, n-2, n-1]
-        :param cut_pdf: Automatically reconstruct pdf with more than 4 pages
-        :param input_type: String in {'path', 'stream', 'base64'}
-        :param file: CarPlate filepath (allowed jpg, png, pdf)
-        :param version: license_plates api version
-        :return: Wrapped response with CarPlates objects parsed
-        """
-        if not self.license_plate_token:
-            raise Exception(
-                "Missing 'license_plate_token' arg in license_plate_token() function."
-            )
-
-        input_file = Inputs(file, input_type, cut_pdf=cut_pdf, n_pdf_pages=cut_pdf_mode)
-
-        response = CarPlate.request(
-            input_file, self.base_url, self.license_plate_token, version
-        )
-
-        return self._wrap_response(input_file, response, "license_plate")
-
-    def parse_invoice(
-        self,
-        file,
-        input_type="path",
-        version="2",
-        cut_pdf=True,
-        include_words=False,
-        cut_pdf_mode=3,
-    ):
-        """
-        :param cut_pdf_mode: Number (between 1 and 3 incl.) of pages to reconstruct a pdf with.
-                        if 1: pages [0]
-                        if 2: pages [0, n-2]
-                        if 3: pages [0, n-2, n-1]
-        :param include_words: Bool, extract all words into http_response
-        :param cut_pdf: Automatically reconstruct pdf with more than 4 pages
-        :param input_type: String in {'path', 'stream', 'base64'}
-        :param file: Invoice filepath (allowed jpg, png, pdf)
-        :param version: invoices api version
-        :return: Wrapped response with Invoices objects parsed
-        """
-        if not self.invoice_token:
-            raise Exception("Missing 'invoice_token' arg in parse_invoice() function.")
-
-        input_file = Inputs(file, input_type, cut_pdf=cut_pdf, n_pdf_pages=cut_pdf_mode)
-
-        response = Invoice.request(
-            input_file, self.base_url, self.invoice_token, version, include_words
-        )
-
-        return self._wrap_response(input_file, response, "invoice")
-
-    def parse_financial_document(
-        self,
-        file,
-        input_type="path",
-        cut_pdf=True,
-        include_words=False,
-        cut_pdf_mode=3,
-    ):
-        """
-        :param cut_pdf_mode: Number (between 1 and 3 incl.) of pages to reconstruct a pdf with.
-                        if 1: pages [0]
-                        if 2: pages [0, n-2]
-                        if 3: pages [0, n-2, n-1]
-        :param include_words: Bool, extract all words into http_response
-        :param cut_pdf: Automatically reconstruct pdf with more than 4 pages
-        :param input_type: String in {'path', 'stream', 'base64'}
-        :param file: Invoice or Receipt filepath (allowed jpg, png, pdf)
-        :return: Wrapped response with FinancialDocument objects parsed
-        """
-        if not self.invoice_token or not self.expense_receipt_token:
-            raise Exception(
-                "parse_invoice() function must include 'invoice_token' and 'expense_receipt_token' args."
-            )
-
-        input_file = Inputs(file, input_type, cut_pdf=cut_pdf, n_pdf_pages=cut_pdf_mode)
-
-        response = FinancialDocument.request(
-            input_file,
-            self.base_url,
-            self.expense_receipt_token,
-            self.invoice_token,
-            include_words,
-        )
-
-        return self._wrap_response(input_file, response, "financial_document")
+DOCUMENT_CLASSES = {
+    "receipt": Receipt,
+    "invoice": Invoice,
+    "financial_document": FinancialDocument,
+    "passport": Passport,
+    "license_plate": CarPlate,
+}
 
 
 class Response(object):

--- a/mindee/documents/car_plate.py
+++ b/mindee/documents/car_plate.py
@@ -1,10 +1,13 @@
 from mindee.documents import Document
 from mindee.fields import Field
-from mindee.http import request
-import os
+from mindee.http import make_api_url, make_api_request
 
 
 class CarPlate(Document):
+
+    ENDPOINT = "license_plates"
+    VERSION = "1"
+
     def __init__(
         self, api_prediction=None, input_file=None, license_plates=None, page_n=0
     ):
@@ -78,16 +81,9 @@ class CarPlate(Document):
         return metrics
 
     @staticmethod
-    def request(input_file, base_url, license_plates_token=None, version="1"):
-        """
-        Make request to license_plates endpoint
-        :param input_file: Input object
-        :param base_url: API base URL
-        :param license_plates_token: License plate API token
-        :param version: API version
-        """
-        url = os.path.join(base_url, "license_plates", "v" + version, "predict")
-        return request(url, input_file, license_plates_token)
+    def request(input_file, token=None):
+        url = make_api_url(CarPlate.ENDPOINT, CarPlate.VERSION)
+        return make_api_request(url, input_file, token)
 
     def _checklist(self):
         """

--- a/mindee/documents/financial_document.py
+++ b/mindee/documents/financial_document.py
@@ -5,10 +5,9 @@ from mindee.fields.orientation import Orientation
 from mindee.fields.tax import Tax
 from mindee.documents import Document
 from mindee.fields import Field
-from mindee.http import request
+from mindee.http import make_api_url, make_api_request
 from mindee.documents.invoice import Invoice
 from mindee.documents.receipt import Receipt
-import os
 
 
 class FinancialDocument(Document):
@@ -202,32 +201,31 @@ class FinancialDocument(Document):
         # Compute Accuracy metrics
         metrics.update(
             FinancialDocument.compute_accuracy(financial_document, ground_truth)
+
         )
+
 
         return metrics
 
     @staticmethod
     def request(
-        input_file,
-        base_url,
-        expense_receipt_token=None,
-        invoice_token=None,
-        include_words=False,
+        input_file, expense_receipt_token=None, invoice_token=None, include_words=False,
     ):
         """
         Make request to invoices endpoint if .pdf, expense_receipts otherwise
-        :param include_words: Bool, extract all words into http_response
         :param input_file: Input object
-        :param base_url: API base URL
         :param expense_receipt_token: Expense receipts API token
         :param invoice_token: Invoices API token
+        :param include_words: Bool, extract all words into http_response
         """
         if "pdf" in input_file.file_extension:
-            url = os.path.join(base_url, "invoices", "v2", "predict")
-            return request(url, input_file, invoice_token, include_words)
+            url = make_api_url(Invoice.ENDPOINT, Invoice.VERSION)
+            return make_api_request(url, input_file, invoice_token, include_words)
         else:
-            url = os.path.join(base_url, "expense_receipts", "v3", "predict")
-            return request(url, input_file, expense_receipt_token, include_words)
+            url = make_api_url(Receipt.ENDPOINT, Receipt.VERSION)
+            return make_api_request(
+                url, input_file, expense_receipt_token, include_words
+            )
 
     def _checklist(self):
         """

--- a/mindee/documents/invoice.py
+++ b/mindee/documents/invoice.py
@@ -6,11 +6,14 @@ from mindee.fields.locale import Locale
 from mindee.fields.orientation import Orientation
 from mindee.fields.payment_details import PaymentDetails
 from mindee.fields.tax import Tax
-from mindee.http import request
-import os
+from mindee.http import make_api_request, make_api_url
 
 
 class Invoice(Document):
+
+    ENDPOINT = "invoices"
+    VERSION = "2"
+
     def __init__(
         self,
         api_prediction=None,
@@ -42,7 +45,6 @@ class Invoice(Document):
         :param supplier: supplier value for creating Invoice object from scratch
         :param payment_details: payment_details value for creating Invoice object from scratch
         :param company_number: company_number value for creating Invoice object from scratch
-        :param vat_number: vat_number value for creating Invoice object from scratch
         :param orientation: orientation value for creating Invoice object from scratch
         :param total_tax: total_tax value for creating Invoice object from scratch
         :param page_n: Page number for multi pages pdf input
@@ -199,19 +201,15 @@ class Invoice(Document):
         return metrics
 
     @staticmethod
-    def request(
-        input_file, base_url, invoice_token=None, version="2", include_words=False
-    ):
+    def request(input_file, token=None, include_words=False):
         """
         Make request to invoices endpoint
         :param input_file: Input object
-        :param base_url: API base URL
-        :param invoice_token: Invoices API token
+        :param token: API token
         :param include_words: Include Mindee vision words in http_response
-        :param version: API version
         """
-        url = os.path.join(base_url, "invoices", "v" + version, "predict")
-        return request(url, input_file, invoice_token, include_words)
+        url = make_api_url(Invoice.ENDPOINT, Invoice.VERSION)
+        return make_api_request(url, input_file, token, include_words)
 
     def _reconstruct(self):
         """

--- a/mindee/documents/passport.py
+++ b/mindee/documents/passport.py
@@ -2,11 +2,14 @@ from mindee.documents import Document
 from mindee.fields import Field
 from mindee.fields.date import Date
 from datetime import datetime
-from mindee.http import request
-import os
+from mindee.http import make_api_url, make_api_request
 
 
 class Passport(Document):
+
+    ENDPOINT = "passport"
+    VERSION = "1"
+
     def __init__(
         self,
         api_prediction=None,
@@ -190,12 +193,9 @@ class Passport(Document):
         return self.expiry_date.date_object < datetime.date(datetime.now())
 
     @staticmethod
-    def request(input_file, base_url, passport_token=None, version="1"):
-        """
-        Make request to passport endpoint
-        """
-        url = os.path.join(base_url, "passport", "v" + version, "predict")
-        return request(url, input_file, passport_token)
+    def request(input_file, token=None):
+        url = make_api_url(Passport.ENDPOINT, Passport.VERSION)
+        return make_api_request(url, input_file, token)
 
     def _reconstruct(self):
         """

--- a/mindee/documents/receipt.py
+++ b/mindee/documents/receipt.py
@@ -5,11 +5,14 @@ from mindee.fields.amount import Amount
 from mindee.fields.locale import Locale
 from mindee.fields.orientation import Orientation
 from mindee.fields.tax import Tax
-from mindee.http import request
-import os
+from mindee.http import make_api_request, make_api_url
 
 
 class Receipt(Document):
+
+    ENDPOINT = "expense_receipts"
+    VERSION = "3"
+
     def __init__(
         self,
         api_prediction=None,
@@ -174,23 +177,16 @@ class Receipt(Document):
         return metrics
 
     @staticmethod
-    def request(
-        input_file,
-        base_url,
-        expense_receipt_token=None,
-        version="3",
-        include_words=False,
+    def request(input_file, token=None, include_words=False,
     ):
         """
         Make request to expense_receipts endpoint
         :param input_file: Input object
-        :param base_url: API base URL
-        :param expense_receipt_token: Expense_receipts API token
+        :param token: Expense_receipts API token
         :param include_words: Include Mindee vision words in http_response
-        :param version: API version
         """
-        url = os.path.join(base_url, "expense_receipts", "v" + version, "predict")
-        return request(url, input_file, expense_receipt_token, include_words)
+        url = make_api_url(Receipt.ENDPOINT, Receipt.VERSION)
+        return make_api_request(url, input_file, token, include_words)
 
     def _checklist(self):
         """

--- a/mindee/http.py
+++ b/mindee/http.py
@@ -1,7 +1,29 @@
 import requests
 
+MINDEE_API_URL = "https://api.mindee.net/v1"
 
-def request(url, input_file, token, include_words=False):
+
+def make_api_url(endpoint: str, version: str, owner: str = "mindee"):
+    """
+    Returns full HTTP URL for a product at specific version
+    :param endpoint: my_api
+    :param version: 1
+    :param owner: mindee
+    :return: full URL, i.e. https://api.mindee.net/v1/products/mindee/invoices/2/predict
+    """
+    return (
+        MINDEE_API_URL
+        + "/products/"
+        + owner
+        + "/"
+        + endpoint
+        + "/"
+        + version
+        + "/predict"
+    )
+
+
+def make_api_request(url, input_file, token, include_words=False):
     """
     :param input_file: Input object
     :param url: Endpoint url


### PR DESCRIPTION
# PR Details

The SDK is not able to parse the HTTP URLs when using on Windows. URLs generation is somehow using python os.path helpers that make path with "/" on Unix systems but "\" on Windows.

## Description

Rewrite URL generation from one single function
Fix Windows URL generation issue

## How Has This Been Tested

This has not been tested properly, only on invoice API.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ x ] Docs change / refactoring / dependency upgrade
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
