### PR TITLE
:label: declare type info to mypy (PEP 561)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
         "test": test_requirements,
     },
     include_package_data=True,
-    package_data={"mindee": ["version"]},
+    package_data={"mindee": ["version", "py.typed"]},
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.7",
@@ -62,4 +62,5 @@ setup(
         "Documentation": "https://developers.mindee.com/docs/python-sdk",
         "Source": "https://github.com/publicMindee/mindee-api-python",
     },
+    zip_safe=False,
 )


### PR DESCRIPTION
# Declare type info to mypy (PEP 561)

## Description
Implement PEP 561 using the `py.typed` marker file.

https://www.python.org/dev/peps/pep-0561/

This fixes the mypy error:
```
Skipping analyzing "mindee": module is installed, but missing library stubs or py.typed marker
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
