### PR TITLE
:sparkles: Allow specifying file closing behavior

### DIFF
--- a/mindee/client.py
+++ b/mindee/client.py
@@ -41,14 +41,20 @@ class DocumentClient:
         self.input_doc = input_doc
 
     def parse(
-        self, document_type: str, username: str = None, include_words: bool = False
+        self,
+        document_type: str,
+        username: str = None,
+        include_words: bool = False,
+        close_file: bool = True,
     ):
         """
         Call prediction API on the document and parse the results.
 
         :param document_type: Document type to parse
-        :param username:
-        :param include_words: Bool, extract all words into http_response
+        :param username: API username, the endpoint owner
+        :param include_words: Extract all words into http_response
+        :param close_file: Whether to `close()` the file after parsing it.
+            Set to `False` if you need to access the file after this operation.
         """
         logger.debug("Parsing document as '%s'", document_type)
 
@@ -87,11 +93,16 @@ class DocumentClient:
                         f"'{endpoint.envvar_key_name}' environment variable."
                     )
                 )
-        return self._make_request(doc_config, include_words)
+        return self._make_request(doc_config, include_words, close_file)
 
-    def _make_request(self, doc_config: DocumentConfig, include_words: bool):
+    def _make_request(
+        self, doc_config: DocumentConfig, include_words: bool, close_file: bool
+    ):
         response = doc_config.constructor.request(
-            doc_config.endpoints, self.input_doc, include_words=include_words
+            doc_config.endpoints,
+            self.input_doc,
+            include_words=include_words,
+            close_file=close_file,
         )
 
         dict_response = response.json()
@@ -112,6 +123,10 @@ class DocumentClient:
         return format_response(
             doc_config, dict_response, doc_config.document_type, self.input_doc
         )
+
+    def close(self) -> None:
+        """Close the file object."""
+        self.input_doc.file_object.close()
 
 
 class Client:

--- a/mindee/documents/base.py
+++ b/mindee/documents/base.py
@@ -42,9 +42,21 @@ class Document:
         self._reconstruct()
 
     @staticmethod
-    def request(endpoints: List[Endpoint], input_file, include_words: bool = False):
-        """Make request to the product endpoint."""
-        raise NotImplementedError()
+    def request(
+        endpoints: List[Endpoint],
+        input_file,
+        include_words: bool = False,
+        close_file: bool = True,
+    ):
+        """
+        Make request to prediction endpoint.
+
+        :param input_file: Input object
+        :param endpoints: Endpoints config
+        :param include_words: Include Mindee vision words in http_response
+        :param close_file: Whether to `close()` the file after parsing it.
+        """
+        return endpoints[0].predict_request(input_file, include_words, close_file)
 
     def build_from_api_prediction(self, api_prediction: dict, page_n):
         """Build the document from an API response JSON."""

--- a/mindee/documents/custom_document.py
+++ b/mindee/documents/custom_document.py
@@ -1,7 +1,6 @@
-from typing import Dict, List
+from typing import Dict
 
 from mindee.documents.base import Document
-from mindee.http import Endpoint
 
 
 class CustomDocument(Document):
@@ -15,6 +14,8 @@ class CustomDocument(Document):
         page_n: int = 0,
     ):
         """
+        Custom document object.
+
         :param document_type: Document type
         :param api_prediction: Raw prediction from HTTP response
         :param input_file: Input object
@@ -29,6 +30,8 @@ class CustomDocument(Document):
 
     def build_from_api_prediction(self, api_prediction, page_n: int = 0):
         """
+        Build the document from an API response JSON.
+
         :param api_prediction: Raw prediction from HTTP response
         :param page_n: Page number for multi pages pdf input
         :return: (void) set the object attributes with api prediction values
@@ -40,9 +43,6 @@ class CustomDocument(Document):
             setattr(self, field_name, field)
 
     def __str__(self) -> str:
-        """
-        :return: (str) String representation of the document
-        """
         custom_doc_str = f"----- {self.type} -----\n"
         for name, info in self.fields.items():
             custom_doc_str += "%s: %s\n" % (
@@ -51,16 +51,6 @@ class CustomDocument(Document):
             )
         custom_doc_str += "-----------------\n"
         return custom_doc_str
-
-    @staticmethod
-    def request(endpoints: List[Endpoint], input_file, include_words: bool = False):
-        """
-        Make request to expense_receipts endpoint
-        :param include_words: Not yet used for custom documents
-        :param input_file: Input object
-        :param endpoints: Endpoints config
-        """
-        return endpoints[0].predict_request(input_file, include_words)
 
     def _checklist(self) -> None:
         pass

--- a/mindee/documents/financial_document.py
+++ b/mindee/documents/financial_document.py
@@ -135,20 +135,26 @@ class FinancialDocument(Document):
         )
 
     @staticmethod
-    def request(endpoints: List[Endpoint], input_file, include_words=False):
+    def request(
+        endpoints: List[Endpoint],
+        input_file,
+        include_words: bool = False,
+        close_file: bool = True,
+    ):
         """
         Make request to prediction endpoint.
 
         :param input_file: Input object
         :param endpoints: Endpoints config
         :param include_words: Include Mindee vision words in http_response
+        :param close_file: Whether to `close()` the file after parsing it.
         """
         if "pdf" in input_file.file_extension:
             # invoices is index 0, receipts 1 (this should be cleaned up)
             index = 0
         else:
             index = 1
-        return endpoints[index].predict_request(input_file, include_words)
+        return endpoints[index].predict_request(input_file, include_words, close_file)
 
     def _checklist(self) -> None:
         """Set the validation rules."""

--- a/mindee/documents/invoice.py
+++ b/mindee/documents/invoice.py
@@ -8,7 +8,6 @@ from mindee.fields.locale import Locale
 from mindee.fields.orientation import Orientation
 from mindee.fields.payment_details import PaymentDetails
 from mindee.fields.tax import Tax
-from mindee.http import Endpoint
 
 
 class Invoice(Document):
@@ -126,17 +125,6 @@ class Invoice(Document):
             f"Locale: {self.locale}\n"
             "----------------------"
         )
-
-    @staticmethod
-    def request(endpoints: List[Endpoint], input_file, include_words=False):
-        """
-        Make request to prediction endpoint.
-
-        :param input_file: Input object
-        :param endpoints: Endpoints config
-        :param include_words: Include Mindee vision words in http_response
-        """
-        return endpoints[0].predict_request(input_file, include_words)
 
     def _reconstruct(self) -> None:
         """Call fields reconstruction methods."""

--- a/mindee/documents/passport.py
+++ b/mindee/documents/passport.py
@@ -4,7 +4,6 @@ from typing import List
 from mindee.documents.base import Document
 from mindee.fields import Field
 from mindee.fields.date import Date
-from mindee.http import Endpoint
 
 
 class Passport(Document):
@@ -103,21 +102,6 @@ class Passport(Document):
         if not self.expiry_date.date_object:
             return False
         return self.expiry_date.date_object < datetime.date(datetime.now())
-
-    @staticmethod
-    def request(endpoints: List[Endpoint], input_file, include_words=False):
-        """
-        Make request to prediction endpoint.
-
-        :param input_file: Input object
-        :param endpoints: Endpoints config
-        :param include_words: Include Mindee vision words in http_response
-        """
-        if include_words:
-            raise ValueError(
-                "include_words parameter cannot be set to True for passport API"
-            )
-        return endpoints[0].predict_request(input_file, include_words)
 
     def _reconstruct(self) -> None:
         """Call fields reconstruction methods."""

--- a/mindee/documents/receipt.py
+++ b/mindee/documents/receipt.py
@@ -7,7 +7,6 @@ from mindee.fields.date import Date
 from mindee.fields.locale import Locale
 from mindee.fields.orientation import Orientation
 from mindee.fields.tax import Tax
-from mindee.http import Endpoint
 
 
 class Receipt(Document):
@@ -98,17 +97,6 @@ class Receipt(Document):
         self.total_excl = Amount(
             {"value": None, "confidence": 0.0}, value_key="value", page_n=page_n
         )
-
-    @staticmethod
-    def request(endpoints: List[Endpoint], input_file, include_words=False):
-        """
-        Make request to prediction endpoint.
-
-        :param input_file: Input object
-        :param endpoints: Endpoints config
-        :param include_words: Include Mindee vision words in http_response
-        """
-        return endpoints[0].predict_request(input_file, include_words)
 
     def _checklist(self) -> None:
         """Call check methods."""

--- a/mindee/inputs.py
+++ b/mindee/inputs.py
@@ -16,6 +16,12 @@ ALLOWED_EXTENSIONS = [
     "application/pdf",
 ]
 
+INPUT_TYPE_FILE = "file"
+INPUT_TYPE_BASE64 = "base64"
+INPUT_TYPE_BYTES = "bytes"
+INPUT_TYPE_PATH = "path"
+INPUT_TYPE_DUMMY = "dummy"
+
 
 class InputDocument:
     file_object: BinaryIO
@@ -35,7 +41,10 @@ class InputDocument:
         self.input_type = input_type
         self.file_extension = guess_type(self.filename)[0]
 
-        if self.file_extension not in ALLOWED_EXTENSIONS and self.input_type != "dummy":
+        if (
+            self.file_extension not in ALLOWED_EXTENSIONS
+            and self.input_type != INPUT_TYPE_DUMMY
+        ):
             raise AssertionError(
                 "File type not allowed, must be in {%s}" % ", ".join(ALLOWED_EXTENSIONS)
             )
@@ -128,6 +137,8 @@ class FileDocument(InputDocument):
         """
         Input document from a Python binary file object.
 
+        Note: the calling function is responsible for closing the file.
+
         :param file: FileIO object
         :param cut_pdf: Automatically reconstruct pdf with more than 4 pages
         """
@@ -135,10 +146,10 @@ class FileDocument(InputDocument):
 
         self.file_object = file
         self.filename = os.path.basename(file.name)
-        self.filepath = self.filename
+        self.filepath = file.name
 
         super().__init__(
-            input_type="file",
+            input_type=INPUT_TYPE_FILE,
             cut_pdf=cut_pdf,
             n_pdf_pages=n_pdf_pages,
         )
@@ -162,7 +173,7 @@ class PathDocument(InputDocument):
         self.filepath = filepath
 
         super().__init__(
-            input_type="path",
+            input_type=INPUT_TYPE_PATH,
             cut_pdf=cut_pdf,
             n_pdf_pages=n_pdf_pages,
         )
@@ -189,7 +200,7 @@ class BytesDocument(InputDocument):
         self.filepath = None
 
         super().__init__(
-            input_type="bytes",
+            input_type=INPUT_TYPE_BYTES,
             cut_pdf=cut_pdf,
             n_pdf_pages=n_pdf_pages,
         )
@@ -215,7 +226,7 @@ class Base64Document(InputDocument):
         self.filepath = None
 
         super().__init__(
-            input_type="base64",
+            input_type=INPUT_TYPE_BASE64,
             cut_pdf=cut_pdf,
             n_pdf_pages=n_pdf_pages,
         )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -209,3 +209,14 @@ def test_interface_version():
         fixed_client.doc_from_path("./tests/data/expense_receipts/receipt.jpg").parse(
             "dummy"
         )
+
+
+def test_keep_file_open(dummy_client):
+    doc = dummy_client.doc_from_path("./tests/data/expense_receipts/receipt.jpg")
+    try:
+        doc.parse("receipt", close_file=False)
+    except HTTPException:
+        pass
+    assert not doc.input_doc.file_object.closed
+    doc.close()
+    assert doc.input_doc.file_object.closed


### PR DESCRIPTION
# :sparkles: Allow specifying file closing behavior

<!--- Provide a general summary of your changes in the Title above -->

## Description

Add the option `close_file` when parsing a document to specify if the file pointer should be closed after processing.


## Motivation and Context

Send the same file to two endpoints without needing to reopen:
```
async def parse_doc(upload: UploadFile):
    """Parse a document."""
    doc = mindee_client.doc_from_bytes(
        upload.file.read(),
        upload.filename,
    )
    custom_response = doc.parse("custom_doc", close_file=False)
    invoice_response = doc.parse("invoice", close_file=True)
```

## How Has This Been Tested

Add unit test.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
