### PR TITLE
:sparkles: add real bounding box

### DIFF
--- a/mindee/fields/amount.py
+++ b/mindee/fields/amount.py
@@ -19,7 +19,7 @@ class Amount(Field):
         :param amount_prediction: Amount prediction object from HTTP response
         :param value_key: Key to use in the amount_prediction dict
         :param reconstructed: Bool for reconstructed object (not extracted in the API)
-        :param page_n: Page number for multi pages pdf
+        :param page_n: Page number for multi-page PDF
         """
         super().__init__(
             amount_prediction,

--- a/mindee/fields/date.py
+++ b/mindee/fields/date.py
@@ -28,7 +28,7 @@ class Date(Field):
         :param date_prediction: Date prediction object from HTTP response
         :param value_key: Key to use in the date_prediction dict
         :param reconstructed: Bool for reconstructed object (not extracted in the API)
-        :param page_n: Page number for multi pages pdf
+        :param page_n: Page number for multi-page PDF
         """
         super().__init__(
             date_prediction,

--- a/mindee/fields/locale.py
+++ b/mindee/fields/locale.py
@@ -24,7 +24,7 @@ class Locale(Field):
         :param locale_prediction: Locale prediction object from HTTP response
         :param value_key: Key to use in the locale_prediction dict
         :param reconstructed: Bool for reconstructed object (not extracted in the API)
-        :param page_n: Page number for multi pages pdf
+        :param page_n: Page number for multi-page PDF
         """
         super().__init__(
             locale_prediction,

--- a/mindee/fields/orientation.py
+++ b/mindee/fields/orientation.py
@@ -18,7 +18,7 @@ class Orientation(Field):
         :param orientation_prediction: Orientation prediction object from HTTP response
         :param value_key: Key to use in the orientation_prediction dict
         :param reconstructed: Bool for reconstructed object (not extracted in the API)
-        :param page_n: Page number for multi pages pdf
+        :param page_n: Page number for multi-page PDF
         """
         super().__init__(
             orientation_prediction,

--- a/mindee/fields/payment_details.py
+++ b/mindee/fields/payment_details.py
@@ -36,7 +36,7 @@ class PaymentDetails(Field):
             payment_details_prediction dict
         :param swift_key: Key to use for getting the SWIFT  in the payment_details_prediction dict
         :param reconstructed: Bool for reconstructed object (not extracted in the API)
-        :param page_n: Page number for multi pages pdf
+        :param page_n: Page number for multi-page PDF
         """
         super().__init__(
             payment_details_prediction,

--- a/mindee/geometry.py
+++ b/mindee/geometry.py
@@ -1,0 +1,33 @@
+"""Pure Python geometry functions for working with polygons."""
+
+from typing import Sequence, Tuple
+
+Point = Tuple[float, float]
+Polygon = Sequence[Point]
+BoundingBox = Tuple[float, float, float, float]
+Quadrilateral = Tuple[Point, Point, Point, Point]
+
+
+def get_bbox_as_polygon(polygon: Polygon) -> Quadrilateral:
+    """
+    Given a sequence of points, calculate a polygon that encompasses all points.
+
+    :param polygon: Sequence of ``Point``
+    :return: Quadrilateral
+    """
+    x_min, y_min, x_max, y_max = get_bbox(polygon)
+    return (x_min, y_min), (x_max, y_min), (x_max, y_max), (x_min, y_max)
+
+
+def get_bbox(polygon: Polygon) -> BoundingBox:
+    """
+    Given a list of points, calculate a bounding box that encompasses all points.
+
+    :param polygon: Sequence of ``Point``
+    :return: BoundingBox
+    """
+    y_min = min(v[1] for v in polygon)
+    y_max = max(v[1] for v in polygon)
+    x_min = min(v[0] for v in polygon)
+    x_max = max(v[0] for v in polygon)
+    return x_min, y_min, x_max, y_max

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,48 @@
+import pytest
+
+from mindee import geometry
+
+
+@pytest.fixture
+def polygon_a():
+    """90° rectangle, overlaps polygon_b"""
+    return [(0.123, 0.53), (0.175, 0.53), (0.175, 0.546), (0.123, 0.546)]
+
+
+@pytest.fixture
+def polygon_b():
+    """90° rectangle, overlaps polygon_a"""
+    return [(0.124, 0.535), (0.190, 0.535), (0.190, 0.546), (0.124, 0.546)]
+
+
+@pytest.fixture
+def polygon_c():
+    """not 90° rectangle, doesn't overlap any polygons"""
+    return [(0.205, 0.407), (0.379, 0.407), (0.381, 0.43), (0.207, 0.43)]
+
+
+def test_bbox(polygon_a, polygon_b, polygon_c):
+    assert geometry.get_bbox(polygon_a) == (0.123, 0.53, 0.175, 0.546)
+    assert geometry.get_bbox(polygon_b) == (0.124, 0.535, 0.19, 0.546)
+    assert geometry.get_bbox(polygon_c) == (0.205, 0.407, 0.381, 0.43)
+
+
+def test_bbox_polygon(polygon_a, polygon_b, polygon_c):
+    assert geometry.get_bbox_as_polygon(polygon_a) == (
+        (0.123, 0.53),
+        (0.175, 0.53),
+        (0.175, 0.546),
+        (0.123, 0.546),
+    )
+    assert geometry.get_bbox_as_polygon(polygon_b) == (
+        (0.124, 0.535),
+        (0.19, 0.535),
+        (0.19, 0.546),
+        (0.124, 0.546),
+    )
+    assert geometry.get_bbox_as_polygon(polygon_c) == (
+        (0.205, 0.407),
+        (0.381, 0.407),
+        (0.381, 0.43),
+        (0.205, 0.43),
+    )


### PR DESCRIPTION
# :sparkles: add real bounding box

API's `polygon` property is now set to the new field property `polygon`.

Existing field property `bbox` is now an actual calculated bounding box.

For OTS products this will have no effect, since currently polygons are always rectangular bounding boxes.

Will be useful when we transition custom docs to object fields.


## Motivation and Context

Required work for Cropper feature and having classes in the custom document response.

## How Has This Been Tested

New unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
