### PR TITLE
:bug: should never use mutable defaults in class definitions

### DIFF
--- a/mindee/documents/bank_check.py
+++ b/mindee/documents/bank_check.py
@@ -13,7 +13,7 @@ class BankCheck(Document):
     """Date the check was issued"""
     amount: Amount
     """Total including taxes"""
-    payees: List[Field] = []
+    payees: List[Field]
     """List of payees (full name or company name)"""
     check_number: Field
     """Check number"""
@@ -23,7 +23,7 @@ class BankCheck(Document):
     """Payer's bank account number"""
     check_position: Field
     """Check's position in the image"""
-    signatures_positions: List[Field] = []
+    signatures_positions: List[Field]
     """Signatures' positions in the image"""
     # orientation is only present on page-level, not document-level
     orientation: Optional[Orientation] = None

--- a/mindee/documents/custom_document.py
+++ b/mindee/documents/custom_document.py
@@ -4,7 +4,7 @@ from mindee.documents.base import Document, TypeApiPrediction
 
 
 class CustomDocument(Document):
-    fields: Dict[str, dict] = {}
+    fields: Dict[str, dict]
     """Dictionary of all fields in the document"""
 
     def __init__(
@@ -38,6 +38,7 @@ class CustomDocument(Document):
         :param api_prediction: Raw prediction from HTTP response
         :param page_n: Page number for multi pages pdf input
         """
+        self.fields = {}
         for field_name in api_prediction:
             field = api_prediction[field_name]
             field["page_n"] = page_n

--- a/mindee/documents/financial_document.py
+++ b/mindee/documents/financial_document.py
@@ -28,7 +28,7 @@ class FinancialDocument(Document):
     """Invoice number"""
     due_date: Date
     """Date the invoice is due"""
-    taxes: List[Tax] = []
+    taxes: List[Tax]
     """List of all taxes"""
     merchant_name: Field
     """Merchant/Supplier's name"""
@@ -38,11 +38,11 @@ class FinancialDocument(Document):
     """Customer's name"""
     customer_address: Field
     """Customer's address"""
-    customer_company_registration: List[TypedField] = []
+    customer_company_registration: List[TypedField]
     """Customer company registration numbers"""
-    payment_details: List[PaymentDetails] = []
+    payment_details: List[PaymentDetails]
     """Payment details"""
-    company_number: List[TypedField] = []
+    company_number: List[TypedField]
     """Company numbers"""
     total_tax: Amount
     """Sum total of all taxes"""
@@ -115,6 +115,9 @@ class FinancialDocument(Document):
             self.merchant_name = receipt.merchant_name
             self.time = receipt.time
             self.total_tax = receipt.total_tax
+            self.customer_company_registration = []
+            self.company_number = []
+            self.payment_details = []
             self.invoice_number = Field({"value": None, "confidence": 0.0})
             self.supplier_address = Field({"value": None, "confidence": 0.0})
             self.customer_name = Field({"value": None, "confidence": 0.0})

--- a/mindee/documents/invoice.py
+++ b/mindee/documents/invoice.py
@@ -35,11 +35,11 @@ class Invoice(Document):
     """Customer's name"""
     customer_address: Field
     """Customer's address"""
-    customer_company_registration: List[TypedField] = []
+    customer_company_registration: List[TypedField]
     """Customer company registration numbers"""
-    payment_details: List[PaymentDetails] = []
+    payment_details: List[PaymentDetails]
     """Payment details"""
-    company_number: List[TypedField] = []
+    company_number: List[TypedField]
     """Company numbers"""
     # orientation is only present on page-level, not document-level
     orientation: Optional[Orientation] = None

--- a/mindee/documents/passport.py
+++ b/mindee/documents/passport.py
@@ -17,7 +17,7 @@ class Passport(Document):
     """Date the passport was issued"""
     surname: Field
     """Holder's last name (surname)"""
-    given_names: List[Field] = []
+    given_names: List[Field]
     """Holder's list of first (given) names"""
     full_name: Field
     """

--- a/mindee/documents/receipt.py
+++ b/mindee/documents/receipt.py
@@ -22,7 +22,7 @@ class Receipt(Document):
     """Service category"""
     merchant_name: Field
     """Merchant's name"""
-    taxes: List[Tax] = []
+    taxes: List[Tax]
     """List of all taxes"""
     total_tax: Amount
     """Sum total of all taxes"""


### PR DESCRIPTION
# :bug: mutable defaults in classes

We should never use mutable defaults in class definitions.

These work the same way as mutable defaults in function definitions, but are not checked by mypy it seems.

Consider using dataclasses in a future version.
https://docs.python.org/3/library/dataclasses.html#mutable-default-values

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)