### PR TITLE
:wastebasket: deprecate setting singular and plural names for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Finally, Python away!
 from mindee import Client
 
 # Init a new client and configure the Invoice API
-mindee_client = Client().config_invoice("my-invoice-api-key")
+mindee_client = Client().config_invoice("my-api-key")
 
 # Load a file from disk and parse it
 api_response = mindee_client.doc_from_path("/path/to/the/invoice.pdf").parse("invoice")
 
 # Print a brief summary of the parsed data
-print(api_response.invoice)
+print(api_response.document)
 ```
 
 ### Custom Document (API Builder)
@@ -33,18 +33,16 @@ from mindee import Client
 
 # Init a new client and configure your custom document
 mindee_client = Client().config_custom_doc(
-      document_type="pokemon-card",
-      singular_name="card",
-      plural_name="cards",
-      account_name="pikachu",
-      api_key="pokemon-card-api-key"
+    account_name="john",
+    document_type="wnine",
+    api_key="my-api-key"
 )
 
 # Load a file from disk and parse it
-api_response = mindee_client.doc_from_path("/path/to/the/card.jpg").parse("pokemon-card")
+api_response = mindee_client.doc_from_path("/path/to/the/card.jpg").parse("wnine")
 
 # Print a brief summary of the parsed data
-print(api_response.card)
+print(api_response.document)
 ```
 
 ## Further Reading

--- a/mindee/client.py
+++ b/mindee/client.py
@@ -141,10 +141,10 @@ class Client:
 
     def config_custom_doc(
         self,
-        document_type: str,
-        singular_name: str,
-        plural_name: str,
         account_name: str,
+        document_type: str,
+        singular_name: str = "",
+        plural_name: str = "",
         api_key: str = "",
         version: str = "1",
     ) -> "Client":

--- a/mindee/response.py
+++ b/mindee/response.py
@@ -10,6 +10,8 @@ class DocumentResponse:
     """Raw HTTP response JSON"""
     document_type: str
     """Document type"""
+    document: Document
+    pages: List[Document]
 
     def __init__(
         self,
@@ -29,8 +31,14 @@ class DocumentResponse:
         """
         self.http_response = http_response
         self.document_type = document_type
-        setattr(self, doc_config.singular_name, document)
-        setattr(self, doc_config.plural_name, pages)
+        self.document = document
+        self.pages = pages
+
+        # Remove all this magic black box stuff in a future version
+        if doc_config.singular_name:
+            setattr(self, doc_config.singular_name, document)
+        if doc_config.plural_name:
+            setattr(self, doc_config.plural_name, pages)
 
 
 def format_response(

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -56,6 +56,8 @@ def test_response_wrapper_invoice(dummy_file_input, dummy_config):
     for page in parsed_response.pages:
         assert isinstance(page, Invoice)
     assert isinstance(parsed_response.invoice, Invoice)
+    for page in parsed_response.invoices:
+        assert isinstance(page, Invoice)
 
 
 # Receipt tests
@@ -70,6 +72,8 @@ def test_response_wrapper_receipt(dummy_file_input, dummy_config):
     for page in parsed_response.pages:
         assert isinstance(page, Receipt)
     assert isinstance(parsed_response.receipt, Receipt)
+    for page in parsed_response.receipts:
+        assert isinstance(page, Receipt)
 
 
 # Financial document tests
@@ -86,3 +90,5 @@ def test_response_wrapper_financial_doc_with_receipt(dummy_file_input, dummy_con
     for page in parsed_response.pages:
         assert isinstance(page, FinancialDocument)
     assert isinstance(parsed_response.financial_doc, FinancialDocument)
+    for page in parsed_response.financial_docs:
+        assert isinstance(page, FinancialDocument)

--- a/tests/test_response.py
+++ b/tests/test_response.py
@@ -4,6 +4,9 @@ import pytest
 
 from mindee import Client
 from mindee.documents.base import Document
+from mindee.documents.financial_document import FinancialDocument
+from mindee.documents.invoice import Invoice
+from mindee.documents.receipt import Receipt
 from mindee.inputs import PathDocument
 from mindee.response import format_response
 from tests.documents.test_invoice import INVOICE_FILE_PATH
@@ -44,12 +47,15 @@ def test_constructor(dummy_file_input):
 
 def test_response_wrapper_invoice(dummy_file_input, dummy_config):
     response = json.load(open(INVOICE_FILE_PATH))
-    parsed_invoice = format_response(
+    parsed_response = format_response(
         dummy_config[("mindee", "invoice")],
         response,
         dummy_file_input,
     )
-    assert parsed_invoice.invoice.invoice_date.value == "2020-02-17"
+    assert isinstance(parsed_response.document, Invoice)
+    for page in parsed_response.pages:
+        assert isinstance(page, Invoice)
+    assert isinstance(parsed_response.invoice, Invoice)
 
 
 # Receipt tests
@@ -57,10 +63,13 @@ def test_response_wrapper_invoice(dummy_file_input, dummy_config):
 
 def test_response_wrapper_receipt(dummy_file_input, dummy_config):
     response = json.load(open(RECEIPT_FILE_PATH))
-    parsed_receipt = format_response(
+    parsed_response = format_response(
         dummy_config[("mindee", "receipt")], response, dummy_file_input
     )
-    assert parsed_receipt.receipt.date.value == "2016-02-26"
+    assert isinstance(parsed_response.document, Receipt)
+    for page in parsed_response.pages:
+        assert isinstance(page, Receipt)
+    assert isinstance(parsed_response.receipt, Receipt)
 
 
 # Financial document tests
@@ -68,19 +77,12 @@ def test_response_wrapper_receipt(dummy_file_input, dummy_config):
 
 def test_response_wrapper_financial_doc_with_receipt(dummy_file_input, dummy_config):
     response = json.load(open(RECEIPT_FILE_PATH))
-    parsed_financial_doc = format_response(
+    parsed_response = format_response(
         dummy_config[("mindee", "financial_doc")],
         response,
         dummy_file_input,
     )
-    assert parsed_financial_doc.financial_doc.date.value == "2016-02-26"
-
-
-def test_response_wrapper_financial_doc_with_invoice(dummy_file_input, dummy_config):
-    response = json.load(open(INVOICE_FILE_PATH))
-    parsed_financial_doc = format_response(
-        dummy_config[("mindee", "financial_doc")],
-        response,
-        dummy_file_input,
-    )
-    assert parsed_financial_doc.financial_doc.date.value == "2020-02-17"
+    assert isinstance(parsed_response.document, FinancialDocument)
+    for page in parsed_response.pages:
+        assert isinstance(page, FinancialDocument)
+    assert isinstance(parsed_response.financial_doc, FinancialDocument)


### PR DESCRIPTION
# Deprecate setting singular and plural names for docs

This feature adds needless complexity to using the library, and has been dropped from Java and Node.js libraries.

Also first step in providing generic functions with proper type information.

Completely backwards compatible.

## How Has This Been Tested

Added unit tests.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
