### PR TITLE
:sparkles: add getting bounding box for multiple polygons

### DIFF
--- a/mindee/fields/base.py
+++ b/mindee/fields/base.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Optional, TypeVar
 
-from mindee.geometry import Polygon, get_bbox_as_polygon
+from mindee.geometry import Polygon, get_bounding_box
 
 TypePrediction = Dict[str, Any]
 
@@ -52,7 +52,7 @@ class Field:
         except KeyError:
             pass
         if self.polygon:
-            self.bbox = get_bbox_as_polygon(self.polygon)
+            self.bbox = get_bounding_box(self.polygon)
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Field):

--- a/mindee/geometry.py
+++ b/mindee/geometry.py
@@ -4,11 +4,11 @@ from typing import Sequence, Tuple
 
 Point = Tuple[float, float]
 Polygon = Sequence[Point]
-BoundingBox = Tuple[float, float, float, float]
+BBox = Tuple[float, float, float, float]
 Quadrilateral = Tuple[Point, Point, Point, Point]
 
 
-def get_bbox_as_polygon(polygon: Polygon) -> Quadrilateral:
+def get_bounding_box(polygon: Polygon) -> Quadrilateral:
     """
     Given a sequence of points, calculate a polygon that encompasses all points.
 
@@ -19,7 +19,7 @@ def get_bbox_as_polygon(polygon: Polygon) -> Quadrilateral:
     return (x_min, y_min), (x_max, y_min), (x_max, y_max), (x_min, y_max)
 
 
-def get_bbox(polygon: Polygon) -> BoundingBox:
+def get_bbox(polygon: Polygon) -> BBox:
     """
     Given a list of points, calculate a bounding box that encompasses all points.
 
@@ -31,6 +31,20 @@ def get_bbox(polygon: Polygon) -> BoundingBox:
     x_min = min(v[0] for v in polygon)
     x_max = max(v[0] for v in polygon)
     return x_min, y_min, x_max, y_max
+
+
+def get_bounding_box_for_polygons(vertices: Sequence[Polygon]) -> Quadrilateral:
+    """
+    Given a list of polygons, calculate a polygon that encompasses all polygons.
+
+    :param vertices: List of polygons
+    :return: Quadrilateral
+    """
+    y_min = min(y for v in vertices for _, y in v)
+    y_max = max(y for v in vertices for _, y in v)
+    x_min = min(x for v in vertices for x, _ in v)
+    x_max = max(x for v in vertices for x, _ in v)
+    return (x_min, y_min), (x_max, y_min), (x_max, y_max), (x_min, y_max)
 
 
 def get_centroid(polygon: Polygon) -> Point:

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -27,20 +27,20 @@ def test_bbox(rectangle_a, rectangle_b, quadrangle_a):
     assert geometry.get_bbox(quadrangle_a) == (0.205, 0.407, 0.381, 0.43)
 
 
-def test_bbox_polygon(rectangle_a, rectangle_b, quadrangle_a):
-    assert geometry.get_bbox_as_polygon(rectangle_a) == (
+def test_bounding_box_single_polygon(rectangle_a, rectangle_b, quadrangle_a):
+    assert geometry.get_bounding_box(rectangle_a) == (
         (0.123, 0.53),
         (0.175, 0.53),
         (0.175, 0.546),
         (0.123, 0.546),
     )
-    assert geometry.get_bbox_as_polygon(rectangle_b) == (
+    assert geometry.get_bounding_box(rectangle_b) == (
         (0.124, 0.535),
         (0.19, 0.535),
         (0.19, 0.546),
         (0.124, 0.546),
     )
-    assert geometry.get_bbox_as_polygon(quadrangle_a) == (
+    assert geometry.get_bounding_box(quadrangle_a) == (
         (0.205, 0.407),
         (0.381, 0.407),
         (0.381, 0.43),
@@ -80,3 +80,12 @@ def test_is_point_in_polygon_x(rectangle_a, rectangle_b, quadrangle_a):
 
 def test_get_centroid(rectangle_a):
     assert geometry.get_centroid(rectangle_a) == (0.149, 0.538)
+
+
+def test_bounding_box_several_polygons(rectangle_b, quadrangle_a):
+    assert geometry.get_bounding_box_for_polygons((rectangle_b, quadrangle_a)) == (
+        (0.124, 0.407),
+        (0.381, 0.407),
+        (0.381, 0.546),
+        (0.124, 0.546),
+    )


### PR DESCRIPTION
## Description
Add a function to get the bounding box of multiple polygons

## Motivation and Context

Useful for certain user functions like line items.

## How Has This Been Tested

Unit test added.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
