### PR TITLE
:sparkles: allow setting timeout value from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ input_doc = mindee_client.doc_from_path("/path/to/the/invoice.pdf")
 api_response = input_doc.parse(documents.TypeInvoiceV3)
 
 # Print a brief summary of the parsed data
-print(str(api_response.document))
+print(api_response.document)
 ```
 
 #### Region-Specific Documents
@@ -46,7 +46,7 @@ input_doc = mindee_client.doc_from_path("/path/to/the/check.jpg")
 api_response = input_doc.parse(documents.us.TypeBankCheckV1)
 
 # Print a brief summary of the parsed data
-print(str(api_response.document))
+print(api_response.document)
 ```
 
 #### Custom Document (API Builder)
@@ -67,7 +67,7 @@ api_response = mindee_client.doc_from_path(
 ).parse(documents.TypeCustomV1, endpoint_name="wnine")
 
 # Print a brief summary of the parsed data
-print(str(api_response.document))
+print(api_response.document)
 
 # Iterate over all the fields in the document
 for field_name, field_values in api_response.document.fields.items():

--- a/mindee/documents/config.py
+++ b/mindee/documents/config.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Tuple, Type
 
 from mindee.documents.base import Document
-from mindee.endpoints import MINDEE_API_KEY_NAME, Endpoint
+from mindee.endpoints import API_KEY_ENVVAR, Endpoint
 
 _docT = Type[Document]
 
@@ -30,7 +30,7 @@ class DocumentConfig:
                         f"Missing API key for '{self.document_type}',"
                         "check your Client configuration.\n"
                         "You can set this using the "
-                        f"'{MINDEE_API_KEY_NAME}' environment variable."
+                        f"'{API_KEY_ENVVAR}' environment variable."
                     )
                 )
 

--- a/mindee/documents/config.py
+++ b/mindee/documents/config.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Tuple, Type
 
 from mindee.documents.base import Document
-from mindee.endpoints import API_KEY_ENVVAR, Endpoint
+from mindee.endpoints import API_KEY_ENV_NAME, Endpoint
 
 _docT = Type[Document]
 
@@ -30,7 +30,7 @@ class DocumentConfig:
                         f"Missing API key for '{self.document_type}',"
                         "check your Client configuration.\n"
                         "You can set this using the "
-                        f"'{API_KEY_ENVVAR}' environment variable."
+                        f"'{API_KEY_ENV_NAME}' environment variable."
                     )
                 )
 

--- a/mindee/endpoints.py
+++ b/mindee/endpoints.py
@@ -7,13 +7,13 @@ from mindee.input.sources import InputSource
 from mindee.logger import logger
 from mindee.versions import __version__, get_platform, python_version
 
-API_KEY_ENVVAR = "MINDEE_API_KEY"
+API_KEY_ENV_NAME = "MINDEE_API_KEY"
 API_KEY_DEFAULT = ""
 
-BASE_URL_ENVVAR = "MINDEE_BASE_URL"
+BASE_URL_ENV_NAME = "MINDEE_BASE_URL"
 BASE_URL_DEFAULT = "https://api.mindee.net/v1"
 
-REQUEST_TIMEOUT_ENVVAR = "MINDEE_REQUEST_TIMEOUT"
+REQUEST_TIMEOUT_ENV_NAME = "MINDEE_REQUEST_TIMEOUT"
 TIMEOUT_DEFAULT = 120
 
 PLATFORM = get_platform()
@@ -71,8 +71,8 @@ class Endpoint:
     def set_from_env(self) -> None:
         """Set various parameters from environment variables, if present."""
         env_vars = {
-            BASE_URL_ENVVAR: self.set_base_url,
-            REQUEST_TIMEOUT_ENVVAR: self.set_timeout,
+            BASE_URL_ENV_NAME: self.set_base_url,
+            REQUEST_TIMEOUT_ENV_NAME: self.set_timeout,
         }
         for name, func in env_vars.items():
             env_val = os.getenv(name, "")
@@ -90,7 +90,7 @@ class Endpoint:
 
     def set_api_key_from_env(self) -> None:
         """Set the endpoint's API key from an environment variable, if present."""
-        env_val = os.getenv(API_KEY_ENVVAR, "")
+        env_val = os.getenv(API_KEY_ENV_NAME, "")
         if env_val:
             self.api_key = env_val
             logger.debug("API key set from environment")

--- a/mindee/endpoints.py
+++ b/mindee/endpoints.py
@@ -1,5 +1,5 @@
 import os
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 import requests
 
@@ -7,16 +7,19 @@ from mindee.input.sources import InputSource
 from mindee.logger import logger
 from mindee.versions import __version__, get_platform, python_version
 
-MINDEE_BASE_URL = "https://api.mindee.net/v1"
-MINDEE_BASE_URL_NAME = "MINDEE_BASE_URL"
-MINDEE_API_KEY_NAME = "MINDEE_API_KEY"
+API_KEY_ENVVAR = "MINDEE_API_KEY"
+API_KEY_DEFAULT = ""
+
+BASE_URL_ENVVAR = "MINDEE_BASE_URL"
+BASE_URL_DEFAULT = "https://api.mindee.net/v1"
+
+REQUEST_TIMEOUT_ENVVAR = "MINDEE_REQUEST_TIMEOUT"
+TIMEOUT_DEFAULT = 120
 
 PLATFORM = get_platform()
 USER_AGENT = f"mindee-api-python@v{__version__} python-v{python_version} {PLATFORM}"
 
 OTS_OWNER = "mindee"
-
-DEFAULT_TIMEOUT = 120
 
 
 class Endpoint:
@@ -25,9 +28,9 @@ class Endpoint:
     owner: str
     url_name: str
     version: str
-    api_key: str = ""
-    timeout: int = DEFAULT_TIMEOUT
-    _mindee_url: str = MINDEE_BASE_URL
+    api_key: str = API_KEY_DEFAULT
+    _request_timeout: int = TIMEOUT_DEFAULT
+    _base_url: str = BASE_URL_DEFAULT
     _url_root: str
 
     def __init__(
@@ -51,10 +54,10 @@ class Endpoint:
             self.api_key = api_key
         else:
             self.set_api_key_from_env()
-        self.set_base_url_from_env()
+        self.set_from_env()
 
         self._url_root = (
-            f"{self._mindee_url}/products/{self.owner}/{self.url_name}/v{self.version}"
+            f"{self._base_url}/products/{self.owner}/{self.url_name}/v{self.version}"
         )
 
     @property
@@ -65,16 +68,29 @@ class Endpoint:
             "User-Agent": USER_AGENT,
         }
 
-    def set_base_url_from_env(self) -> None:
-        """Set the base URL from an environment variable, if present."""
-        env_val = os.getenv(MINDEE_BASE_URL_NAME, "")
-        if env_val:
-            self._mindee_url = env_val
-            logger.debug("Base URL set from environment")
+    def set_from_env(self) -> None:
+        """Set various parameters from environment variables, if present."""
+        env_vars = {
+            BASE_URL_ENVVAR: self.set_base_url,
+            REQUEST_TIMEOUT_ENVVAR: self.set_timeout,
+        }
+        for name, func in env_vars.items():
+            env_val = os.getenv(name, "")
+            if env_val:
+                func(env_val)
+                logger.debug("Value was set from env: %s", name)
+
+    def set_timeout(self, value: Union[str, int]) -> None:
+        """Set the timeout for all requests."""
+        self._request_timeout = int(value)
+
+    def set_base_url(self, value: str) -> None:
+        """Set the base URL for all requests."""
+        self._base_url = value
 
     def set_api_key_from_env(self) -> None:
         """Set the endpoint's API key from an environment variable, if present."""
-        env_val = os.getenv(MINDEE_API_KEY_NAME, "")
+        env_val = os.getenv(API_KEY_ENVVAR, "")
         if env_val:
             self.api_key = env_val
             logger.debug("API key set from environment")
@@ -110,7 +126,7 @@ class Endpoint:
             headers=self.base_headers,
             data=data,
             params=params,
-            timeout=self.timeout,
+            timeout=self._request_timeout,
         )
         return response
 
@@ -134,7 +150,7 @@ class CustomEndpoint(Endpoint):
             files=files,
             headers=self.base_headers,
             params=params,
-            timeout=self.timeout,
+            timeout=self._request_timeout,
         )
         return response
 
@@ -156,7 +172,7 @@ class CustomEndpoint(Endpoint):
             files=files,
             headers=self.base_headers,
             params=params,
-            timeout=self.timeout,
+            timeout=self._request_timeout,
         )
         return response
 
@@ -175,7 +191,7 @@ class CustomEndpoint(Endpoint):
             f"{self._url_root}/documents/{document_id}",
             headers=self.base_headers,
             params=params,
-            timeout=self.timeout,
+            timeout=self._request_timeout,
         )
         return response
 
@@ -188,7 +204,7 @@ class CustomEndpoint(Endpoint):
         response = requests.delete(
             f"{self._url_root}/documents/{document_id}",
             headers=self.base_headers,
-            timeout=self.timeout,
+            timeout=self._request_timeout,
         )
         return response
 
@@ -205,7 +221,7 @@ class CustomEndpoint(Endpoint):
             f"{self._url_root}/documents",
             headers=self.base_headers,
             params=params,
-            timeout=self.timeout,
+            timeout=self._request_timeout,
         )
         return response
 
@@ -223,7 +239,7 @@ class CustomEndpoint(Endpoint):
             f"{self._url_root}/documents/{document_id}/annotations",
             headers=self.base_headers,
             json=annotations,
-            timeout=self.timeout,
+            timeout=self._request_timeout,
         )
         return response
 
@@ -241,7 +257,7 @@ class CustomEndpoint(Endpoint):
             f"{self._url_root}/documents/{document_id}/annotations",
             headers=self.base_headers,
             json=annotations,
-            timeout=self.timeout,
+            timeout=self._request_timeout,
         )
         return response
 
@@ -255,7 +271,7 @@ class CustomEndpoint(Endpoint):
         response = requests.delete(
             f"{self._url_root}/documents/{document_id}/annotations",
             headers=self.base_headers,
-            timeout=self.timeout,
+            timeout=self._request_timeout,
         )
         return response
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,8 @@
-from mindee.endpoints import API_KEY_ENVVAR, BASE_URL_ENVVAR, REQUEST_TIMEOUT_ENVVAR
+from mindee.endpoints import (
+    API_KEY_ENV_NAME,
+    BASE_URL_ENV_NAME,
+    REQUEST_TIMEOUT_ENV_NAME,
+)
 
 
 def clear_envvars(monkeypatch):
@@ -6,13 +10,13 @@ def clear_envvars(monkeypatch):
     If we have envvars set, the test will pick them up and fail,
     so let's make sure they're empty.
     """
-    monkeypatch.setenv(API_KEY_ENVVAR, "")
-    monkeypatch.setenv(BASE_URL_ENVVAR, "")
-    monkeypatch.setenv(REQUEST_TIMEOUT_ENVVAR, "")
+    monkeypatch.setenv(API_KEY_ENV_NAME, "")
+    monkeypatch.setenv(BASE_URL_ENV_NAME, "")
+    monkeypatch.setenv(REQUEST_TIMEOUT_ENV_NAME, "")
 
 
 def dummy_envvars(monkeypatch):
     """
     Set all API keys to 'dummy'.
     """
-    monkeypatch.setenv(API_KEY_ENVVAR, "dummy")
+    monkeypatch.setenv(API_KEY_ENV_NAME, "dummy")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,4 @@
-from mindee.endpoints import MINDEE_API_KEY_NAME
+from mindee.endpoints import API_KEY_ENVVAR, BASE_URL_ENVVAR, REQUEST_TIMEOUT_ENVVAR
 
 
 def clear_envvars(monkeypatch):
@@ -6,11 +6,13 @@ def clear_envvars(monkeypatch):
     If we have envvars set, the test will pick them up and fail,
     so let's make sure they're empty.
     """
-    monkeypatch.setenv(MINDEE_API_KEY_NAME, "")
+    monkeypatch.setenv(API_KEY_ENVVAR, "")
+    monkeypatch.setenv(BASE_URL_ENVVAR, "")
+    monkeypatch.setenv(REQUEST_TIMEOUT_ENVVAR, "")
 
 
 def dummy_envvars(monkeypatch):
     """
     Set all API keys to 'dummy'.
     """
-    monkeypatch.setenv(MINDEE_API_KEY_NAME, "dummy")
+    monkeypatch.setenv(API_KEY_ENVVAR, "dummy")


### PR DESCRIPTION
## Description
Allow setting the request timeout from  `MINDEE_REQUEST_TIMEOUT` envvar


## How Has This Been Tested
Manual testing :-(


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
