### PR TITLE
Add async CLI support

### DIFF
--- a/docs/guide/python-cli.md
+++ b/docs/guide/python-cli.md
@@ -10,20 +10,32 @@ python3 -m mindee --help
 ### Example command help
 
 ```shell
-python3 -m mindee invoice --help
+python3 -m mindee invoice parse --help
 ```
 
 ### Example parse command for Off-the-Shelf document
 
 ```shell
-python3 -m mindee invoice --invoice-key xxxxxxx /path/to/invoice.pdf
+python3 -m mindee invoice parse --key xxxxxxx /path/to/invoice.pdf
+```
+
+### Example enqueue command for Off-the-Shelf document (async)
+
+```shell
+python3 -m mindee invoice-splitter enqueue --key xxxxxxx /path/to/invoice-splitter.pdf
+```
+
+### Example parse-queued command for Off-the-Shelf document (async)
+
+```shell
+python3 -m mindee invoice-splitter parse-queued --key xxxxxxx id-of-the-job
 ```
 
 ### Works with environment variables
 
 ```shell
 export MINDEE_API_KEY=xxxxxx
-python3 -m mindee invoice /path/to/invoice.pdf
+python3 -m mindee invoice parse /path/to/invoice.pdf
 ```
 
 ### Example parse command for a custom document
@@ -35,7 +47,7 @@ python3 -m mindee custom -u pikachu -k xxxxxxx pokemon_card /path/to/card.jpg
 ### You can get the full parsed output as well
 
 ```shell
-python3 -m mindee invoice -o parsed /path/to/invoice.pdf
+python3 -m mindee invoice parse -o parsed /path/to/invoice.pdf
 ```
 
 ### In the Git repo, there's a helper script for it

--- a/docs/predictions/standard/international.rst
+++ b/docs/predictions/standard/international.rst
@@ -9,5 +9,6 @@ International
 .. include:: ./documents/financial_document_v1.rst
 .. include:: ./documents/passport_v1.rst
 .. include:: ./documents/shipping_container_v1.rst
+.. include:: ./documents/invoice_splitter_v1.rst
 .. include:: ./documents/proof_of_address_v1.rst
 .. include:: ./documents/cropper_v1.rst

--- a/mindee/cli.py
+++ b/mindee/cli.py
@@ -158,7 +158,7 @@ def call_endpoint(args: Namespace):
                 doc = parsed_data.document.document
                 print(json.dumps(doc, indent=2, default=serialize_for_json))
             else:
-                print(parsed_data.document.document_type)
+                print(parsed_data.document.document)
         else:
             print(parsed_data.job)
     elif args.instruction_type == "parse":

--- a/mindee/cli.py
+++ b/mindee/cli.py
@@ -191,7 +191,7 @@ def _parse_args() -> Namespace:
     
     for name, info in DOCUMENTS.items():
         subp = subparsers.add_parser(name, help=info.help)
-        parsers_instruction_type = subp.add_subparsers(dest="instruction_type")
+        parsers_instruction_type = subp.add_subparsers(dest="instruction_type", required=True)
         
         if info.is_sync:
             subp_predict = parsers_instruction_type.add_parser("parse", help=f"Parse {name}")
@@ -201,9 +201,11 @@ def _parse_args() -> Namespace:
             parser_enqueue = parsers_instruction_type.add_parser("enqueue", help=f"Enqueue {name}")
             _add_options(parser_enqueue, "enqueue", name)
             
-            parser_parse_queued = parsers_instruction_type.add_parser("parse-queued", help=f"Parse (queued) {name} <queue_id>")
+            parser_parse_queued = parsers_instruction_type.add_parser("parse-queued", help=f"Parse (queued) {name}")
             _add_options(parser_parse_queued, "parse-queued", name)
+            parser_parse_queued.add_argument(dest="queue_id", help="Async queue ID for a document (required)")
             
+        subp.add_argument(dest="path", help="Full path to the file")
 
     parsed_args = parser.parse_args()
     return parsed_args

--- a/mindee/cli.py
+++ b/mindee/cli.py
@@ -152,7 +152,7 @@ def process_parse(args: Namespace, client: Client, doc_class) -> None:
 
 def process_parse_queued(args: Namespace, client: Client, doc_class) -> None:
     """Processes the results of a queued parsing request."""
-    input_doc = client.no_doc()
+    input_doc = client.doc_for_async()
     if args.product_name == "custom":
         parsed_data = input_doc.parse_queued(
             document_class=doc_class,
@@ -164,8 +164,7 @@ def process_parse_queued(args: Namespace, client: Client, doc_class) -> None:
         parsed_data = input_doc.parse_queued(
             document_class=doc_class, queue_id=args.queue_id
         )
-    if parsed_data.job.status == "completed":
-        input_doc = _get_input_doc(client, args, parsed_data.api_request.url)
+    if parsed_data.job.status == "completed" and parsed_data.document is not None:
         if args.output_type == "raw":
             print(json.dumps(parsed_data.document.http_response, indent=2))
         elif args.output_type == "parsed":

--- a/mindee/cli.py
+++ b/mindee/cli.py
@@ -181,14 +181,14 @@ def process_parse_enqueue(args: Namespace, client: Client, doc_class) -> None:
     input_doc = _get_input_doc(client, args)
     if args.product_name == "custom":
         client.add_endpoint(
-            endpoint_name=args.api_name,
-            account_name=args.account,
+            endpoint_name=args.endpoint_name,
+            account_name=args.account_name,
             version=args.api_version,
         )
         parsed_data = input_doc.enqueue(
             doc_class,
-            endpoint_name=args.api_name,
-            account_name=args.account,
+            endpoint_name=args.endpoint_name,
+            account_name=args.account_name,
             page_options=page_options,
         )
     else:

--- a/mindee/cli.py
+++ b/mindee/cli.py
@@ -200,12 +200,6 @@ def _parse_args() -> Namespace:
         dest="raise_on_error",
         help="don't raise errors",
     )
-    parser.add_argument(
-        "-k",
-        "--key",
-        dest="api_key",
-        help="API key for the account",
-    )
     subparsers = parser.add_subparsers(
         dest="product_name",
         required=True,
@@ -243,6 +237,12 @@ def _add_options(parser:ArgumentParser, category: str, name:str):
     :param name: Name of the current command (Default/Custom).
     """
     
+    parser.add_argument(
+        "-k",
+        "--key",
+        dest="api_key",
+        help="API key for the account",
+    )
     
     if category in ["predict", "enqueue"]:
         parser.add_argument(

--- a/mindee/client.py
+++ b/mindee/client.py
@@ -75,7 +75,7 @@ class DocumentClient:
             This performs a cropping operation on the server and will increase response time.
         """
         if self.input_doc is None:
-            raise RuntimeError("The 'parse' function requires an input document.")
+            raise TypeError("The 'parse' function requires an input document.")
         bound_classname = get_bound_classname(document_class)
         if bound_classname != documents.CustomV1.__name__:
             endpoint_name = get_bound_classname(document_class)
@@ -139,7 +139,7 @@ class DocumentClient:
             This performs a cropping operation on the server and will increase response time.
         """
         if self.input_doc is None:
-            raise RuntimeError("The 'enqueue' function requires an input document.")
+            raise TypeError("The 'enqueue' function requires an input document.")
         bound_classname = get_bound_classname(document_class)
         if bound_classname != documents.CustomV1.__name__:
             endpoint_name = get_bound_classname(document_class)
@@ -203,7 +203,7 @@ class DocumentClient:
         if get_bound_classname(document_class) != doc_config.document_class.__name__:
             raise RuntimeError("Document class mismatch!")
         if self.input_doc is None:
-            raise RuntimeError(
+            raise TypeError(
                 "The '_make_request' class method requires an input document."
             )
         response = doc_config.document_class.request(
@@ -241,7 +241,7 @@ class DocumentClient:
         :param doc_config: Configuration of the document.
         """
         if self.input_doc is None:
-            raise RuntimeError(
+            raise TypeError(
                 "The '_predict_async' class method requires an input document."
             )
         response = doc_config.endpoints[0].predict_async_req_post(

--- a/mindee/client.py
+++ b/mindee/client.py
@@ -583,3 +583,13 @@ class Client:
             doc_configs=self._doc_configs,
             raise_on_error=self.raise_on_error,
         )
+
+    def no_doc(
+        self
+    ):
+        return DocumentClient(
+            input_doc=None,
+            doc_configs=self._doc_configs,
+            raise_on_error=self.raise_on_error,
+        )
+        

--- a/mindee/client.py
+++ b/mindee/client.py
@@ -584,12 +584,19 @@ class Client:
             raise_on_error=self.raise_on_error,
         )
 
-    def no_doc(
-        self
-    ):
+    def no_doc(self) -> DocumentClient:
+        """
+        Load an empty dummy document.
+
+        Used when calling parse-queued to avoid having to use a formerly
+        created DocumentClientObject.
+        """
+        input_doc = BytesInput(
+            bytearray(),
+            "",
+        )
         return DocumentClient(
-            input_doc=None,
+            input_doc=input_doc,
             doc_configs=self._doc_configs,
             raise_on_error=self.raise_on_error,
         )
-        

--- a/mindee/client.py
+++ b/mindee/client.py
@@ -268,7 +268,7 @@ class DocumentClient:
             or queue_response.status_code > 302
         ):
             raise HTTPException(
-                f"API {queue_response.status_code} HTTP error: {json.dumps(queue_response)}"
+                f"API {queue_response.status_code} HTTP error: {json.dumps(queue_response.json())}"
             )
 
         return AsyncPredictResponse[TypeDocument](

--- a/mindee/documents/base.py
+++ b/mindee/documents/base.py
@@ -46,7 +46,7 @@ class Document:
 
     def __init__(
         self,
-        input_source: Union[LocalInputSource, UrlInputSource],
+        input_source: Optional[Union[LocalInputSource, UrlInputSource]],
         document_type: Optional[str],
         api_prediction: TypeApiPrediction,
         page_n: Optional[int] = None,

--- a/mindee/response.py
+++ b/mindee/response.py
@@ -111,7 +111,7 @@ class PredictResponse(Generic[TypeDocument]):
             self.input_filename = input_source.filename
             self.input_mimetype = input_source.file_mimetype
 
-        if not response_ok or not input_source:
+        if not response_ok:
             self.document = None
         else:
             self._load_response(doc_config, input_source)

--- a/mindee/response.py
+++ b/mindee/response.py
@@ -60,7 +60,10 @@ class Job:
         self.job_id = json_response.get("id")
         self.status = json_response.get("status")
         if self.available_at:
-            self.millisecs_taken = int((self.available_at-self.issued_at).total_seconds()*1000)
+            self.millisecs_taken = int(
+                (self.available_at - self.issued_at).total_seconds() * 1000
+            )
+
     def __str__(self) -> str:
         return json.dumps(self.__dict__, indent=4, sort_keys=True, default=str)
 
@@ -91,7 +94,7 @@ class PredictResponse(Generic[TypeDocument]):
         self,
         doc_config: DocumentConfig,
         http_response: Dict[str, Any],
-        input_source: Optional[Union[LocalInputSource, UrlInputSource]],
+        input_source: Union[LocalInputSource, UrlInputSource],
         response_ok: bool,
     ) -> None:
         """
@@ -106,12 +109,12 @@ class PredictResponse(Generic[TypeDocument]):
         self.document_type = doc_config.document_type
         self.pages = []
 
-        if not isinstance(input_source, UrlInputSource) and input_source:
+        if not isinstance(input_source, UrlInputSource):
             self.input_path = input_source.filepath
             self.input_filename = input_source.filename
             self.input_mimetype = input_source.file_mimetype
 
-        if not response_ok:
+        if not response_ok or not input_source:
             self.document = None
         else:
             self._load_response(doc_config, input_source)

--- a/mindee/response.py
+++ b/mindee/response.py
@@ -60,10 +60,7 @@ class Job:
         self.job_id = json_response.get("id")
         self.status = json_response.get("status")
         if self.available_at:
-            self.millisecs_taken = int(
-                (self.available_at.microsecond - self.issued_at.microsecond) / 1000
-            )
-
+            self.millisecs_taken = int((self.available_at-self.issued_at).total_seconds()*1000)
     def __str__(self) -> str:
         return json.dumps(self.__dict__, indent=4, sort_keys=True, default=str)
 
@@ -94,7 +91,7 @@ class PredictResponse(Generic[TypeDocument]):
         self,
         doc_config: DocumentConfig,
         http_response: Dict[str, Any],
-        input_source: Union[LocalInputSource, UrlInputSource],
+        input_source: Optional[Union[LocalInputSource, UrlInputSource]],
         response_ok: bool,
     ) -> None:
         """
@@ -109,12 +106,12 @@ class PredictResponse(Generic[TypeDocument]):
         self.document_type = doc_config.document_type
         self.pages = []
 
-        if not isinstance(input_source, UrlInputSource):
+        if not isinstance(input_source, UrlInputSource) and input_source:
             self.input_path = input_source.filepath
             self.input_filename = input_source.filename
             self.input_mimetype = input_source.file_mimetype
 
-        if not response_ok:
+        if not response_ok or not input_source:
             self.document = None
         else:
             self._load_response(doc_config, input_source)

--- a/mindee/response.py
+++ b/mindee/response.py
@@ -94,7 +94,7 @@ class PredictResponse(Generic[TypeDocument]):
         self,
         doc_config: DocumentConfig,
         http_response: Dict[str, Any],
-        input_source: Union[LocalInputSource, UrlInputSource],
+        input_source: Optional[Union[LocalInputSource, UrlInputSource]],
         response_ok: bool,
     ) -> None:
         """
@@ -109,12 +109,12 @@ class PredictResponse(Generic[TypeDocument]):
         self.document_type = doc_config.document_type
         self.pages = []
 
-        if not isinstance(input_source, UrlInputSource):
+        if isinstance(input_source, LocalInputSource):
             self.input_path = input_source.filepath
             self.input_filename = input_source.filename
             self.input_mimetype = input_source.file_mimetype
 
-        if not response_ok or not input_source:
+        if not response_ok:
             self.document = None
         else:
             self._load_response(doc_config, input_source)
@@ -122,7 +122,7 @@ class PredictResponse(Generic[TypeDocument]):
     def _load_response(
         self,
         doc_config: DocumentConfig,
-        input_source: Union[LocalInputSource, UrlInputSource],
+        input_source: Optional[Union[LocalInputSource, UrlInputSource]],
     ) -> None:
         # This is some seriously ugly stuff.
         # Simplify all this in V4, as we won't need to pass the document type anymore
@@ -169,13 +169,13 @@ class AsyncPredictResponse(Generic[TypeDocument]):
     api_request: ApiRequest
     job: Job
     """Job object link to the prediction. As long as it isn't complete, the prediction doesn't exist."""
-    document: PredictResponse[TypeDocument]
+    document: Optional[PredictResponse[TypeDocument]]
 
     def __init__(
         self,
         http_response: Dict[str, Any],
         doc_config: DocumentConfig,
-        input_source: Union[LocalInputSource, UrlInputSource],
+        input_source: Optional[Union[LocalInputSource, UrlInputSource]],
         response_ok: bool,
     ) -> None:
         """

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,8 +12,8 @@ def custom_doc(monkeypatch):
     clear_envvars(monkeypatch)
     return Namespace(
         product_name="custom",
-        api_name="license_plate",
-        username="mindee",
+        endpoint_name="license_plate",
+        account_name="mindee",
         api_key="dummy",
         api_version="1",
         raise_on_error=True,
@@ -23,7 +23,7 @@ def custom_doc(monkeypatch):
         output_type="summary",
         include_words=False,
         path="./tests/data/pdf/blank.pdf",
-        instruction_type="parse",
+        call_method="parse",
     )
 
 
@@ -39,7 +39,7 @@ def ots_doc(monkeypatch):
         output_type="summary",
         include_words=False,
         path="./tests/data/invoice/invoice.pdf",
-        instruction_type="parse",
+        call_method="parse",
     )
 
 
@@ -54,7 +54,7 @@ def ots_doc_enqueue(monkeypatch):
         input_type="path",
         include_words=False,
         path="./tests/data/invoice_splitter/2_invoices.pdf",
-        instruction_type="enqueue",
+        call_method="enqueue",
     )
 
 
@@ -66,7 +66,7 @@ def ots_doc_parse_queued(monkeypatch):
         raise_on_error=True,
         output_type="summary",
         queue_id="dummy-queue-id",
-        instruction_type="parse-queued",
+        call_method="parse-queued",
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,7 @@ def custom_doc(monkeypatch):
         output_type="summary",
         include_words=False,
         path="./tests/data/pdf/blank.pdf",
+        instruction_type="parse",
     )
 
 
@@ -38,6 +39,34 @@ def ots_doc(monkeypatch):
         output_type="summary",
         include_words=False,
         path="./tests/data/invoice/invoice.pdf",
+        instruction_type="parse",
+    )
+
+
+@pytest.fixture
+def ots_doc_enqueue(monkeypatch):
+    clear_envvars(monkeypatch)
+    return Namespace(
+        api_key="dummy",
+        raise_on_error=True,
+        cut_doc=False,
+        doc_pages=3,
+        input_type="path",
+        include_words=False,
+        path="./tests/data/invoice_splitter/2_invoices.pdf",
+        instruction_type="enqueue",
+    )
+
+
+@pytest.fixture
+def ots_doc_parse_queued(monkeypatch):
+    clear_envvars(monkeypatch)
+    return Namespace(
+        api_key="dummy",
+        raise_on_error=True,
+        output_type="summary",
+        queue_id="dummy-queue-id",
+        instruction_type="parse-queued",
     )
 
 
@@ -94,3 +123,23 @@ def test_cli_us_bank_check(ots_doc):
     ots_doc.api_key = "dummy"
     with pytest.raises(HTTPException):
         call_endpoint(ots_doc)
+
+
+def test_cli_invoice_splitter_enqueue(ots_doc_enqueue):
+    ots_doc_enqueue.product_name = "invoice-splitter"
+    ots_doc_enqueue.api_key = ""
+    with pytest.raises(RuntimeError):
+        call_endpoint(ots_doc_enqueue)
+    ots_doc_enqueue.api_key = "dummy"
+    with pytest.raises(HTTPException):
+        call_endpoint(ots_doc_enqueue)
+
+
+def test_cli_invoice_splitter_parse_queued(ots_doc_parse_queued):
+    ots_doc_parse_queued.product_name = "invoice-splitter"
+    ots_doc_parse_queued.api_key = ""
+    with pytest.raises(RuntimeError):
+        call_endpoint(ots_doc_parse_queued)
+    ots_doc_parse_queued.api_key = "dummy"
+    with pytest.raises(HTTPException):
+        call_endpoint(ots_doc_parse_queued)


### PR DESCRIPTION
## Description

#### Breaking Changes:
- New keyword `parse` in CLI is now required to parse older commands (see the [guide](./docs/guide) for more detail).

#### Additions:
- Added support for asynchronous requests in CLI
- Added Invoice Splitter support in CLI (asynchronous)
- Refactored CLI code to accommodate for future additions
- Added keywords `enqueue` and `parse-queued` in CLI

#### Bug fixes:
- Fixed InvoiceSplitterV1 auto-documentation page
- Fixed HTTP message display error from `parse_queued` jobs
- Fixed delay calculation for asynchronous job completion
## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires a change to the official Guide documentation.
