### PR TITLE
:test_tube: :sparkles: add **experimental** pdf-fixing utility

### DIFF
--- a/mindee/client.py
+++ b/mindee/client.py
@@ -454,7 +454,10 @@ class Client:
 
         :param input_path: Path of file to open
         """
-        return PathInput(input_path, fix_pdf=fix_pdf)
+        input_doc = PathInput(input_path)
+        if fix_pdf:
+            input_doc.fix_pdf()
+        return input_doc
 
     def source_from_file(
         self, input_file: BinaryIO, fix_pdf: bool = False
@@ -464,7 +467,10 @@ class Client:
 
         :param input_file: Input file handle
         """
-        return FileInput(input_file, fix_pdf=fix_pdf)
+        input_doc = FileInput(input_file)
+        if fix_pdf:
+            input_doc.fix_pdf()
+        return input_doc
 
     def source_from_b64string(
         self, input_string: str, filename: str, fix_pdf: bool = False
@@ -475,7 +481,10 @@ class Client:
         :param input_string: Input to parse as base64 string
         :param filename: The name of the file (without the path)
         """
-        return Base64Input(input_string, filename, fix_pdf=fix_pdf)
+        input_doc = Base64Input(input_string, filename)
+        if fix_pdf:
+            input_doc.fix_pdf()
+        return input_doc
 
     def source_from_bytes(
         self, input_bytes: bytes, filename: str, fix_pdf: bool = False
@@ -486,7 +495,10 @@ class Client:
         :param input_bytes: Raw byte input
         :param filename: The name of the file (without the path)
         """
-        return BytesInput(input_bytes, filename, fix_pdf=fix_pdf)
+        input_doc = BytesInput(input_bytes, filename)
+        if fix_pdf:
+            input_doc.fix_pdf()
+        return input_doc
 
     def source_from_url(
         self,

--- a/mindee/client.py
+++ b/mindee/client.py
@@ -447,33 +447,27 @@ class Client:
         return self._build_endpoint(endpoint_name, account_name, version)
 
     def source_from_path(
-        self,
-        input_path: Union[Path, str],
+        self, input_path: Union[Path, str], fix_pdf: bool = False
     ) -> PathInput:
         """
         Load a document from an absolute path, as a string.
 
         :param input_path: Path of file to open
         """
-        return PathInput(input_path)
+        return PathInput(input_path, fix_pdf=fix_pdf)
 
     def source_from_file(
-        self,
-        input_file: BinaryIO,
+        self, input_file: BinaryIO, fix_pdf: bool = False
     ) -> FileInput:
         """
         Load a document from a normal Python file object/handle.
 
         :param input_file: Input file handle
         """
-        return FileInput(
-            input_file,
-        )
+        return FileInput(input_file, fix_pdf=fix_pdf)
 
     def source_from_b64string(
-        self,
-        input_string: str,
-        filename: str,
+        self, input_string: str, filename: str, fix_pdf: bool = False
     ) -> Base64Input:
         """
         Load a document from a base64 encoded string.
@@ -481,15 +475,10 @@ class Client:
         :param input_string: Input to parse as base64 string
         :param filename: The name of the file (without the path)
         """
-        return Base64Input(
-            input_string,
-            filename,
-        )
+        return Base64Input(input_string, filename, fix_pdf=fix_pdf)
 
     def source_from_bytes(
-        self,
-        input_bytes: bytes,
-        filename: str,
+        self, input_bytes: bytes, filename: str, fix_pdf: bool = False
     ) -> BytesInput:
         """
         Load a document from raw bytes.
@@ -497,10 +486,7 @@ class Client:
         :param input_bytes: Raw byte input
         :param filename: The name of the file (without the path)
         """
-        return BytesInput(
-            input_bytes,
-            filename,
-        )
+        return BytesInput(input_bytes, filename, fix_pdf=fix_pdf)
 
     def source_from_url(
         self,

--- a/mindee/input/sources.py
+++ b/mindee/input/sources.py
@@ -61,7 +61,7 @@ class LocalInputSource:
             self.file_mimetype = file_mimetype
         else:
             raise MimeTypeError(f"Could not determine MIME type of '{self.filename}'.")
-        if self.fix_pdf and self.filename.lower().endswith(".pdf"):
+        if self.fix_pdf:
             try:
                 buf = self.file_object.read()
                 self.file_object.seek(0)

--- a/mindee/input/sources.py
+++ b/mindee/input/sources.py
@@ -66,7 +66,6 @@ class LocalInputSource:
                 buf = self.file_object.read()
                 self.file_object.seek(0)
                 pos: int = buf.find(b"%PDF-")
-                print(f"POS: {pos}")
                 if pos != -1 and pos < 500:
                     self.file_object.seek(pos)
                     raw_bytes = self.file_object.read()

--- a/mindee/input/sources.py
+++ b/mindee/input/sources.py
@@ -2,9 +2,9 @@ import base64
 import io
 import mimetypes
 import os
+import tempfile
 from enum import Enum
 from pathlib import Path
-import tempfile
 from typing import BinaryIO, Optional, Sequence, Tuple, Union
 
 import pikepdf
@@ -70,26 +70,25 @@ class LocalInputSource:
                 if pos != -1 and pos < 500:
                     self.file_object.seek(pos)
                     raw_bytes = self.file_object.read()
-                    fp = tempfile.TemporaryFile()
-                    fp.write(raw_bytes)
-                    fp.seek(0)
-                    self.file_object = io.BytesIO(fp.read())
-                    fp.close()
+                    temp_file = tempfile.TemporaryFile()
+                    temp_file.write(raw_bytes)
+                    temp_file.seek(0)
+                    self.file_object = io.BytesIO(temp_file.read())
+                    temp_file.close()
                 else:
                     if pos < 0:
                         raise MimeTypeError(
                             "Provided stream isn't a valid PDF-like object."
                         )
-                    else:
-                        raise MimeTypeError(
-                            f"PDF couldn't be fixed. PDF tag was found at position {pos}."
-                        )
+                    raise MimeTypeError(
+                        f"PDF couldn't be fixed. PDF tag was found at position {pos}."
+                    )
                 self.file_mimetype = "application/pdf"
-            except MimeTypeError as e:
-                raise e
-            except Exception as e:
-                print(f"Attempt to fix pdf raised exception {e}.")
-                raise e
+            except MimeTypeError as exc:
+                raise exc
+            except Exception as exc:
+                print(f"Attempt to fix pdf raised exception {exc}.")
+                raise exc
 
         if self.file_mimetype not in ALLOWED_MIME_TYPES:
             file_types = ", ".join(ALLOWED_MIME_TYPES)

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -169,6 +169,7 @@ def test_pdf_blank_check():
     input_not_blank = PathInput(FILE_TYPES_DIR / "pdf" / "not_blank_image_only.pdf")
     assert input_not_blank.count_doc_pages() == 1
 
+
 #
 # Broken PDFS fixing
 #
@@ -177,7 +178,7 @@ def test_pdf_blank_check():
 def test_broken_unfixable_pdf():
     with pytest.raises(MimeTypeError):
         PathInput(FILE_TYPES_DIR / "pdf" / "broken_unfixable.pdf", fix_pdf=True)
-        
+
 
 def test_broken_fixable_pdf():
     PathInput(FILE_TYPES_DIR / "pdf" / "broken_fixable.pdf", fix_pdf=True)
@@ -185,6 +186,7 @@ def test_broken_fixable_pdf():
 
 def test_broken_fixable_invoice_pdf():
     PathInput(FILE_TYPES_DIR / "pdf" / "broken_invoice.pdf", fix_pdf=True)
+
 
 #
 # Images

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -177,15 +177,18 @@ def test_pdf_blank_check():
 
 def test_broken_unfixable_pdf():
     with pytest.raises(MimeTypeError):
-        PathInput(FILE_TYPES_DIR / "pdf" / "broken_unfixable.pdf", fix_pdf=True)
+        input_doc = PathInput(FILE_TYPES_DIR / "pdf" / "broken_unfixable.pdf")
+        input_doc.fix_pdf()
 
 
 def test_broken_fixable_pdf():
-    PathInput(FILE_TYPES_DIR / "pdf" / "broken_fixable.pdf", fix_pdf=True)
+    input_doc = PathInput(FILE_TYPES_DIR / "pdf" / "broken_fixable.pdf")
+    input_doc.fix_pdf()
 
 
 def test_broken_fixable_invoice_pdf():
-    PathInput(FILE_TYPES_DIR / "pdf" / "broken_invoice.pdf", fix_pdf=True)
+    input_doc = PathInput(FILE_TYPES_DIR / "pdf" / "broken_invoice.pdf")
+    input_doc.fix_pdf()
 
 
 #

--- a/tests/test_inputs.py
+++ b/tests/test_inputs.py
@@ -169,6 +169,22 @@ def test_pdf_blank_check():
     input_not_blank = PathInput(FILE_TYPES_DIR / "pdf" / "not_blank_image_only.pdf")
     assert input_not_blank.count_doc_pages() == 1
 
+#
+# Broken PDFS fixing
+#
+
+
+def test_broken_unfixable_pdf():
+    with pytest.raises(MimeTypeError):
+        PathInput(FILE_TYPES_DIR / "pdf" / "broken_unfixable.pdf", fix_pdf=True)
+        
+
+def test_broken_fixable_pdf():
+    PathInput(FILE_TYPES_DIR / "pdf" / "broken_fixable.pdf", fix_pdf=True)
+
+
+def test_broken_fixable_invoice_pdf():
+    PathInput(FILE_TYPES_DIR / "pdf" / "broken_invoice.pdf", fix_pdf=True)
 
 #
 # Images


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Add a fixing utility to try and delete garbage in PDF headers. Solves _some_ issues with files interpreted as octet streams, and also allows to circumvent errors due to missing file name when giving a temp file.

## Related Issue
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
* Partially addresses #126 

## How Has This Been Tested
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
* CI
* Integration testing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
