### PR TITLE
:white_check_mark: better control over import linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/ambv/black
-    rev: 24.1.1
+    rev: 24.4.0
     hooks:
       - id: black
 
@@ -8,7 +8,7 @@ repos:
     rev: 5.13.2
     hooks:
       - id: isort
-        args: [ "--profile", "black" ]
+        args: [ "--profile", "black" , "--split-on-trailing-comma", "true"]
         additional_dependencies: [toml]
 
   - repo: https://github.com/pycqa/pydocstyle


### PR DESCRIPTION
## Description
Allow us humans to better control the look of imports.
By adding a trailing comma we can now force to use the multiline layout even if not strictly needed.
This makes it easier to generate code, there was much rejoicing throughout the land.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
