### PR TITLE
:sparkles: support printing the OCR text in the CLI tool

### DIFF
--- a/mindee/cli.py
+++ b/mindee/cli.py
@@ -361,6 +361,11 @@ class MindeeParser:
         else:
             if response.document is None:
                 raise MindeeClientError("Something went wrong during async parsing.")
+            # print the OCR
+            if self.parsed_args.include_words:
+                print("#############\nDocument Text\n#############\n::\n")
+                print("  " + str(response.document.ocr).replace("\n", "\n  "))
+            # print the response as rST
             print(self._doc_str(self.parsed_args.output_type, response.document))
 
     def _parse_sync(self) -> PredictResponse:


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
<!--- Why is this change required? What problem does it solve? -->
Print the full OCR text to console when passing the `-t` argument in CLI.

Not sure why we didn't do this already.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires a change to the official Guide documentation.
